### PR TITLE
NATS: do not drain in-flight messages

### DIFF
--- a/packages/nats/README.md
+++ b/packages/nats/README.md
@@ -90,6 +90,28 @@ Disconnects from the NATS server and clears all subscriptions.
 
 Convenience factory that returns a `Qified` instance configured with `NatsMessageProvider`.
 
+## Draining Messages
+
+NATS allows processing in-flight messages before unsubscribing/disconnecting. If this is needed, override unsubscribe and/or disconnect methods and call drain instead of unsubscribe/close.
+
+```typescript
+public async unsubscribe(topic: string, id?: string): Promise<void> {
+    // ...
+    await this._subscriptions.get(topic)?.drain();
+    // ...
+}
+```
+
+```typescript
+public async disconnect(): Promise<void> {
+    // ...
+    await this._connection?.drain();
+    // ...
+}
+```
+
+Please read [NATS Pub/Sub](https://github.com/nats-io/nats.js/blob/main/core/README.md) to know about message draining.
+
 ## Contributing
 
 Contributions are welcome! Please read the [CONTRIBUTING.md](../../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md) for details on our process.

--- a/packages/nats/src/index.ts
+++ b/packages/nats/src/index.ts
@@ -104,7 +104,7 @@ export class NatsMessageProvider implements MessageProvider {
 				);
 			}
 		} else {
-			await this._subscriptions.get(topic)?.drain();
+			this._subscriptions.get(topic)?.unsubscribe();
 			this._subscriptions.delete(topic);
 
 			this.subscriptions.delete(topic);
@@ -118,7 +118,7 @@ export class NatsMessageProvider implements MessageProvider {
 	public async disconnect(): Promise<void> {
 		this.subscriptions.clear();
 
-		await this._connection?.drain();
+		await this._connection?.close();
 		this._connection = undefined;
 	}
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] Followed the [Contributing](../CONTRIBUTING.md) guidelines.
- [X] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [X] Docs have been added / updated (for bug fixes / features)

To be  consistent with other providers, do not drain messages already queued at unsubscribe/disconnect as no other provider offer such facility on its own.

User can still override default behaviour if they need it.