### PR TITLE
mono - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -41,7 +41,7 @@ jobs:
       run: pnpm test:ci
       
     - name: Code Coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./packages/qified/coverage/lcov.info, \

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -36,13 +36,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Enable corepack
       run: corepack enable
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -52,7 +52,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
@@ -60,6 +60,6 @@ jobs:
       run: pnpm build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -33,7 +33,7 @@ jobs:
       run: pnpm website:build
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         command: pages deploy site/dist --project-name=qified --branch=main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,11 +21,11 @@ jobs:
         node-version: ['22', '24', '26']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
## Summary
Upgrade every `uses: <action>@<ref>` reference across `.github/workflows/` to the latest major.

## Versions
- `actions/checkout` `v4` → `v6`
- `actions/setup-node` `v4` → `v6`
- `cloudflare/wrangler-action` `v3` → `v4`
- `codecov/codecov-action` `v5` → `v6`
- `github/codeql-action/init` `v3` → `v4`
- `github/codeql-action/analyze` `v3` → `v4`

## Tests
- [x] All workflow YAML files parse
- [x] No input/option changes needed — `cache: 'pnpm'`, `pages deploy ...`, token + files inputs remain compatible across the major bumps

## Breaking notes
- `actions/checkout@v6` and `actions/setup-node@v6` require Actions runner `v2.329.0+` (GitHub-hosted `ubuntu-latest` already satisfies).
- `cloudflare/wrangler-action@v4` now installs Wrangler v4 by default — `pages deploy` CLI surface is unchanged.
- `codecov/codecov-action@v6` requires Node 24 on the runner (already in use).
- Pin style preserved as `@vX` throughout.


---
_Generated by [Claude Code](https://claude.ai/code/session_016ijMPA9wKGB1f5kpHCdvT1)_