### PR TITLE
@qified/nats - chore: remove deprecated nats package

### DIFF
--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@nats-io/jetstream": "^3.3.1",
     "@nats-io/transport-node": "^3.3.1",
-    "hookified": "^2.1.1",
-    "nats": "^2.29.3"
+    "hookified": "^2.1.1"
   },
   "peerDependencies": {
     "qified": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       hookified:
         specifier: ^2.1.1
         version: 2.2.0
-      nats:
-        specifier: ^2.29.3
-        version: 2.29.3
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -1795,17 +1792,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nats@2.29.3:
-    resolution: {integrity: sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==}
-    engines: {node: '>= 14.0.0'}
-    deprecated: Package moved. Use @nats-io/transport-node from https://github.com/nats-io/nats.js
-
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  nkeys.js@1.1.0:
-    resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
-    engines: {node: '>=10.0.0'}
 
   node-addon-api@8.7.0:
     resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
@@ -4225,15 +4213,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nats@2.29.3:
-    dependencies:
-      nkeys.js: 1.1.0
-
   neo-async@2.6.2: {}
-
-  nkeys.js@1.1.0:
-    dependencies:
-      tweetnacl: 1.0.3
 
   node-addon-api@8.7.0: {}
 


### PR DESCRIPTION
## Summary
Remove the deprecated `nats` package from `@qified/nats`. It is not imported anywhere in the workspace — the package already uses the modern `@nats-io/jetstream` and `@nats-io/transport-node` clients.

## Versions
- `nats` `2.29.3` → removed

## Tests
- [x] `pnpm build` passes for all 5 workspace packages
- [x] `pnpm test` passes for `qified` core (132/132, coverage 100%)
- [x] `biome check` and `tsc --noEmit` clean on `@qified/nats`
- [x] Broker-backed `@qified/nats` tests need NATS service via Docker — CI will verify

## Breaking notes
None. The deprecated `nats@2.x` symbol set was never imported in `packages/nats/src/`. `connect`/`NatsConnection` come from `@nats-io/transport-node`; jetstream APIs come from `@nats-io/jetstream`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016ijMPA9wKGB1f5kpHCdvT1)_