### PR TITLE
release: v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/mono",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "engines": {

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/nats",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "NATS message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qified",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Task and Message Queues with Multiple Providers",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/rabbitmq",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "RabbitMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/redis",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Redis message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/zeromq",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "ZeroMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Release summary
Dependency-management release: drops the deprecated `nats` package, bumps `amqplib` to v2, and refreshes dev tooling. All five published packages move together to `0.11.0` per the repo's locked-version policy.

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `qified` | `0.10.1` | `0.11.0` | **minor** | locked-version bump (no own-path changes) | 0 |
| `@qified/nats` | `0.10.1` | `0.11.0` | **minor** | dropped deprecated `nats` dep | 1 |
| `@qified/rabbitmq` | `0.10.1` | `0.11.0` | **minor** | `amqplib` 1.x → 2.x (breaking transitive); dropped `@types/amqplib` | 2 |
| `@qified/redis` | `0.10.1` | `0.11.0` | **minor** | locked-version bump (no own-path changes) | 0 |
| `@qified/zeromq` | `0.10.1` | `0.11.0` | **minor** | locked-version bump (no own-path changes) | 0 |
| `@qified/mono` | `0.10.1` | `0.11.0` | _private_ | workspace root, not published | 4 |

## v0.11.0 — 2026-05-18

Dependency-management release: drops the deprecated `nats` package, bumps `amqplib` to v2, and refreshes dev tooling.

### ⚠ BREAKING CHANGES
- bump `amqplib` runtime dep from `1.x` to `2.0.1` in `@qified/rabbitmq` (8af4e55, #195)
  Migration: the only documented v2 break is `heartbeat: 0` now disables heartbeats (previously "no preference"). `@qified/rabbitmq` does not expose a heartbeat option, so consumers do not need to change anything.
- remove deprecated `nats@2.x` dependency from `@qified/nats` (4e5c8e1, #196)
  Migration: `@qified/nats` no longer transitively provides the legacy `nats` package. The modern `@nats-io/jetstream` and `@nats-io/transport-node` clients are still shipped. Consumers that import the legacy `nats` package directly should add it to their own `dependencies`.

### Internal
- upgrade to pnpm 11 via corepack and bump test matrix to Node 22/24/26 (bca34c3, #192)
- override `@ungap/structured-clone` to `>=1.3.1` (CWE-502) (7526167, #192)
- upgrade `tsdown` to `0.22.0` (ef91092, #193)
- align root `engines.node` with `tsdown` 0.22.0 floor (`^22.18.0 || >=24.0.0`) (06ae52a, #193)
- upgrade GitHub Actions to latest majors — checkout v6, setup-node v6, wrangler-action v4, codecov-action v6, codeql-action v4 (bce0018, #194)
- drop redundant `@types/amqplib` devDep — amqplib v2 ships its own types (b691337, #195)

### Contributors
- @jaredwray

**Full diff:** https://github.com/jaredwray/qified/compare/v0.10.1...v0.11.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds across all 5 published packages
- [x] `pnpm test` passes for `qified` core (132/132, 100% coverage); broker-backed tests verified by CI (Docker not available in sandbox)
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge this PR, then create a GitHub Release at tag `v0.11.0` — `.github/workflows/release.yaml` triggers on `release: released` and runs `pnpm publish:packages` to push all five packages to npm.


---
_Generated by [Claude Code](https://claude.ai/code/session_016ijMPA9wKGB1f5kpHCdvT1)_