### PR TITLE
mono - fix: allow sharp and workerd build scripts so site deploy succeeds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,5 +26,7 @@ trustPolicyExclude:
 # Approved build scripts — code-reviewed allowlist (replaces onlyBuiltDependencies)
 allowBuilds:
   esbuild: true
+  sharp: true
   unrs-resolver: true
+  workerd: true
   zeromq: true


### PR DESCRIPTION
## Summary

The `deploy-site` workflow fails at the **Publish to Cloudflare Pages** step with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5, workerd@1.20260507.1
Error: The process '/usr/local/bin/pnpm' failed with exit code 1
```

Root cause: `cloudflare/wrangler-action@v4` does not find a local wrangler install and runs `pnpm add wrangler@4` dynamically at deploy time. That pulls in `sharp` and `workerd` as transitive deps, both of which have postinstall scripts (binary fetchers). With `strictDepBuilds: true` in `pnpm-workspace.yaml`, pnpm refuses to silently ignore these and exits 1 because neither package is in the `allowBuilds` allowlist.

Fix: add `sharp` (lovell/sharp — libvips bindings) and `workerd` (Cloudflare's Workers runtime) to `allowBuilds`, matching the existing pattern for `esbuild`, `unrs-resolver`, and `zeromq`.

Verified locally by reproducing the action's flow:
- `pnpm install --frozen-lockfile` → ok
- `pnpm add wrangler@4` → both build scripts now run cleanly, exits 0

## Test plan

- [ ] Re-run the `deploy-site` workflow (workflow_dispatch) on this branch and confirm the **Publish to Cloudflare Pages** step succeeds
- [ ] Confirm regular `pnpm install` on the workspace still completes without prompting for build approvals

https://claude.ai/code/session_01LhBEQopYnEKDK8ZYMSymTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhBEQopYnEKDK8ZYMSymTJ)_