### PR TITLE
ci: pass CLOUDFLARE_ACCOUNT_ID to wrangler-action

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -36,4 +36,5 @@ jobs:
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: pages deploy site/dist --project-name=qified --branch=main


### PR DESCRIPTION
## Summary

The `deploy-site` workflow was only passing `apiToken` to `cloudflare/wrangler-action@v4`. Without an explicit `accountId`, wrangler falls back to the `CLOUDFLARE_ACCOUNT_ID` env var — which is empty in CI — and constructs `/accounts//pages/projects/qified` (note the double slash). Cloudflare's API rejects that with code 7003:

```
Could not route to /client/v4/accounts/pages/projects/qified, perhaps your object identifier is invalid? [code: 7003]
```

This PR wires `accountId` through from a repo secret.

## Required follow-up

**The `CLOUDFLARE_ACCOUNT_ID` repository secret must be added in GitHub repo settings** for this fix to take effect. I can't set secret values, only reference them.

## Test plan

- [ ] Add `CLOUDFLARE_ACCOUNT_ID` to repo secrets
- [ ] Trigger `deploy-site` workflow (release or workflow_dispatch) and confirm the deploy succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhBEQopYnEKDK8ZYMSymTJ)_