### PR TITLE
mono - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -41,7 +41,7 @@ jobs:
       run: pnpm test:ci
       
     - name: Code Coverage
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./packages/qified/coverage/lcov.info, \


### PR DESCRIPTION
## Summary
Upgrade `codecov/codecov-action` to its latest major (v7) in the code-coverage workflow. This is the only outdated GitHub Action — `actions/checkout@v6`, `actions/setup-node@v6`, `github/codeql-action@v4`, and `cloudflare/wrangler-action@v4` are already on their latest majors.

## Versions
- `codecov/codecov-action` `v6` → `v7`

## Checks
- [x] Workflow YAML still parses
- [x] `token` and `files` inputs are unchanged and remain supported in v7

## Breaking notes
The action's major version bumped v6 → v7 (hence the `(breaking)` tag), but our usage only sets `token` and `files`, both still supported in v7, so no configuration changes were required beyond the version pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMNkABBFNLZF5131aiGwrZ)_