### PR TITLE
ci: migrate npm release to OIDC trusted publishing with provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,12 @@ on:
   release:
     types: [released]
 
+# OIDC trusted publishing to npm requires id-token: write so the job can mint
+# the OIDC token that npm exchanges for a short-lived publish credential. No
+# long-lived NPM_TOKEN is needed and provenance attestations are generated.
 permissions:
   contents: read
-
-env:
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  id-token: write
 
 jobs:
   build:
@@ -29,7 +30,7 @@ jobs:
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
     - name: Test Services
@@ -41,13 +42,5 @@ jobs:
     - name: Testing
       run: pnpm test
 
-    - name: create npmrc
-      run: |
-        echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-        echo "always-auth=true" >> ~/.npmrc
-
     - name: Publish
-      run: |
-        pnpm publish:packages
-        
-
+      run: pnpm publish:packages

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --access public --no-git-checks",
+    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [
@@ -32,6 +32,11 @@
     "publish",
     "subscribe"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jaredwray/qified.git",
+    "directory": "packages/nats"
+  },
   "author": "Jared Wray <me@jaredwray.com>",
   "contributors": [
     "Santosh Bandichode <santoshg550@gmail.com>"

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage ./site/dist",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --access public --no-git-checks",
+    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [
@@ -33,7 +33,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jaredwray/qified.git"
+    "url": "git+https://github.com/jaredwray/qified.git",
+    "directory": "packages/qified"
   },
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --access public --no-git-checks",
+    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [
@@ -30,6 +30,11 @@
     "message",
     "provider"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jaredwray/qified.git",
+    "directory": "packages/rabbitmq"
+  },
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "dependencies": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --access public --no-git-checks",
+    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [
@@ -30,6 +30,11 @@
     "message",
     "provider"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jaredwray/qified.git",
+    "directory": "packages/redis"
+  },
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "dependencies": {

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --access public --no-git-checks",
+    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [
@@ -30,6 +30,11 @@
     "message",
     "provider"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jaredwray/qified.git",
+    "directory": "packages/zeromq"
+  },
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

Migrates the release pipeline from a long-lived `NPM_TOKEN` secret to **GitHub Actions OIDC trusted publishing**, and enables **npm provenance** attestations for every published package. Everything stays on **pnpm** — no `npm`/`npx` invocations are introduced.

The repo already pins `pnpm@11.1.2` via `packageManager` + corepack. pnpm's native publish flow (since 11.0) handles the OIDC token exchange and provenance itself using bundled `libnpmpublish`, so no system `npm` upgrade is required.

## Changes

**`.github/workflows/release.yaml`**
- Added `id-token: write` permission so the job can mint the OIDC token npm exchanges for a short-lived publish credential.
- Removed the `env: NPM_TOKEN` and the hand-written `~/.npmrc` step — no static token is needed anymore.
- Publish step is now just `pnpm publish:packages`.

**`packages/*/package.json` (all 5 packages)**
- Added `--provenance` to each `build:publish` script (`pnpm publish --provenance --access public --no-git-checks`).
- Added a `repository` field with a monorepo `directory` to the `redis`, `rabbitmq`, `nats`, and `zeromq` providers, and a `directory` to `qified`. npm provenance **requires** a public `repository` that matches the source it is published from, so the providers (which had no `repository` field) would have failed provenance generation without this.

## ⚠️ One-time setup required before the next release

OIDC trusted publishing won't authenticate until a **trusted publisher** is configured on npmjs.com for **each** package (`qified`, `@qified/redis`, `@qified/rabbitmq`, `@qified/nats`, `@qified/zeromq`). On each package's npm settings page → *Trusted Publishers*, add a GitHub Actions publisher with (case-sensitive):

| Field | Value |
| --- | --- |
| Organization / user | `jaredwray` |
| Repository | `qified` |
| Workflow filename | `release.yaml` |
| Environment | *(leave blank — none configured)* |

Once configured, the `NPM_TOKEN` repo secret can be deleted. Trusted publishing requires a cloud-hosted runner (`ubuntu-latest` ✓) and public repo for provenance to be emitted — both already satisfied.

## Verification

- All 5 `package.json` files validated as parseable JSON; `repository`/`build:publish` fields confirmed correct.
- Confirmed the pinned pnpm `11.1.2` resolves via corepack and **accepts** `--provenance` (a deliberately bogus flag is rejected with `Unknown option`, while `--provenance` passes), and that `provenance` is a recognized pnpm config key.
- Verified the workflow no longer references any `secrets.*`/`NODE_AUTH_TOKEN`/`.npmrc`.

> Note: `pnpm test` exercises only `src/`/`test/` TypeScript (Biome is scoped to those globs) and the provider suites require Docker services; this change is release-pipeline + `package.json` metadata only and does not touch source or tests.

https://claude.ai/code/session_015xP5N3Wz14pL14dc3pyYsg

---
_Generated by [Claude Code](https://claude.ai/code/session_015xP5N3Wz14pL14dc3pyYsg)_