### PR TITLE
release: v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/mono",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "engines": {

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/nats",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "NATS message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qified",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Task and Message Queues with Multiple Providers",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/rabbitmq",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "RabbitMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/redis",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Redis message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/zeromq",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "ZeroMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Release summary
Dependency-management release: redis 6, hookified 3, and OIDC trusted publishing with provenance. All five published packages bump `0.11.0 → 0.12.0` in lockstep (fixed-version monorepo).

## Packages
| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `qified` | `0.11.0` | `0.12.0` | **minor** | hookified 2→3 (major dep), provenance | 2 |
| `@qified/redis` | `0.11.0` | `0.12.0` | **minor** | redis 5→6 (major dep, RESP3), hookified 3 | 3 |
| `@qified/rabbitmq` | `0.11.0` | `0.12.0` | **minor** | hookified 2→3 (major dep), provenance | 2 |
| `@qified/nats` | `0.11.0` | `0.12.0` | **minor** | hookified 3, @nats-io 3.4, provenance | 2 |
| `@qified/zeromq` | `0.11.0` | `0.12.0` | **minor** | provenance + repo metadata (lockstep) | 1 |
| `@qified/mono` (root) | `0.11.0` | `0.12.0` | _private_ | not published; bumped to hold lockstep | 3 |

## v0.12.0 — 2026-06-16

Dependency-management release: redis 6, hookified 3, and OIDC trusted publishing with provenance.

### ⚠ BREAKING CHANGES
- upgrade `redis` runtime dependency `5.12.1` → `6.0.0` in `@qified/redis` (ffaa82f, #202)
  Migration: redis 6 makes RESP3 the default wire protocol and requires Node 20+ (qified already requires 22+). `@qified/redis` builds and passes its full live-Redis suite unchanged, so the provider's own API is unaffected. Consumers that reach the underlying client or depend on RESP2 reply shapes should pass `RESP: 2` in their client options.

### Changed
- upgrade `hookified` runtime dependency `2.1.1` → `3.0.0` in `qified`, `@qified/redis`, `@qified/rabbitmq`, and `@qified/nats` (a035b2a, #200)
- upgrade `@nats-io/jetstream` and `@nats-io/transport-node` `3.3.1` → `3.4.0` in `@qified/nats` (a035b2a, #200)

### Internal
- migrate npm publishing to OIDC trusted publishing and emit provenance attestations for all five packages; add `repository.directory` metadata required for provenance (e7a4c4f, #203)
- upgrade `codecov-action` v6 → v7 (a256689, #201)
- pass `CLOUDFLARE_ACCOUNT_ID` to `wrangler-action` so the site deploy routes correctly (0abd413, #199)
- allow `sharp` and `workerd` build scripts so the Cloudflare Pages deploy succeeds (fbd79ce, #198)
- refresh dev tooling — biome 2.4.16, @types/node 25.9.2, vitest 4.1.8, tsdown 0.22.2, tsx 4.22.4, docula 2.0.0 (a035b2a, #200)

### Contributors
- @jaredwray

### Full List of Changes
- mono - fix: allow sharp and workerd build scripts so site deploy succeeds by @jaredwray in #198
- ci: pass CLOUDFLARE_ACCOUNT_ID to wrangler-action by @jaredwray in #199
- chore(deps): agentic dependency management update by @jaredwray in #200
- mono - chore: upgrade GitHub Actions (breaking) by @jaredwray in #201
- @qified/redis - chore: upgrade redis to 6.0.0 (breaking) by @jaredwray in #202
- ci: migrate npm release to OIDC trusted publishing with provenance by @jaredwray in #203

**Full diff:** https://github.com/jaredwray/qified/compare/v0.11.0...v0.12.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds — lockfile up to date
- [x] `pnpm build` succeeds — all 5 packages compile
- [x] `qified` core: `pnpm --filter qified test` → 132 tests pass, lint clean, 100% statement/function/line coverage
- [ ] Provider suites (`@qified/redis`/`rabbitmq`/`nats`/`zeromq`) require live Docker services — run in CI
- [x] No changes outside the version bump (no `CHANGELOG.md` is kept in this repo; release notes live here + in the GitHub Release)

## Post-merge
- Merge, then **create a GitHub Release at tag `v0.12.0`** — the `release.yaml` workflow (`release: [released]`) runs `pnpm publish:packages`, publishing all five packages to npm via OIDC trusted publishing with provenance.
- ⚠️ One-time prerequisite (from #203): configure the npm **Trusted Publisher** for each package (`qified`, `@qified/redis`, `@qified/rabbitmq`, `@qified/nats`, `@qified/zeromq`) on npmjs.com before the first OIDC publish, otherwise the publish step will fail to authenticate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiZJiKrjNRTLw7EXwamDCp)_