### PR TITLE
feat(valkey): add @qified/valkey provider

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -46,5 +46,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./packages/qified/coverage/lcov.info, \
          ./packages/redis/coverage/lcov.info, \
+         ./packages/valkey/coverage/lcov.info, \
          ./packages/nats/coverage/lcov.info, \
          ./packages/rabbitmq/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a mono repo that contains the following packages:
 
 Additional packages:
 * [@qified/redis](packages/redis/README.md) - Redis Provider (messages and tasks)
+* [@qified/valkey](packages/valkey/README.md) - Valkey Provider (messages and tasks)
 * [@qified/rabbitmq](packages/rabbitmq/README.md) - RabbitMQ Provider (messages and tasks)
 * [@qified/nats](packages/nats/README.md) - NATS Provider (messages and tasks)
 * [@qified/zeromq](packages/zeromq/README.md) - ZeroMQ Provider (messages only)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,12 @@ services:
     ports:
       - "6379:6379" # Redis port
 
+  valkey:
+    image: valkey/valkey:latest
+    container_name: valkey
+    ports:
+      - "6380:6379" # Valkey port (host 6380; redis already uses 6379)
+
   nats:
     image: nats:latest
     container_name: nats

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -134,10 +134,14 @@ export class RedisMessageProvider implements MessageProvider {
 			this.subscriptions.set(topic, []);
 			const subClient = await this.getSubClient();
 			await subClient.subscribe(topic, async (raw) => {
-				const message = JSON.parse(raw) as Message;
-				/* v8 ignore next -- @preserve */
-				const handlers = this.subscriptions.get(topic) ?? [];
-				await Promise.all(handlers.map(async (sub) => sub.handler(message)));
+				try {
+					const message = JSON.parse(raw) as Message;
+					/* v8 ignore next -- @preserve */
+					const handlers = this.subscriptions.get(topic) ?? [];
+					await Promise.all(handlers.map(async (sub) => sub.handler(message)));
+				} catch {
+					// Ignore malformed messages to prevent process crashes.
+				}
 			});
 		}
 

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -132,17 +132,26 @@ export class RedisMessageProvider implements MessageProvider {
 	async subscribe(topic: string, handler: TopicHandler): Promise<void> {
 		if (!this.subscriptions.has(topic)) {
 			this.subscriptions.set(topic, []);
-			const subClient = await this.getSubClient();
-			await subClient.subscribe(topic, async (raw) => {
-				try {
-					const message = JSON.parse(raw) as Message;
-					/* v8 ignore next -- @preserve */
-					const handlers = this.subscriptions.get(topic) ?? [];
-					await Promise.all(handlers.map(async (sub) => sub.handler(message)));
-				} catch {
-					// Ignore malformed messages to prevent process crashes.
-				}
-			});
+			try {
+				const subClient = await this.getSubClient();
+				await subClient.subscribe(topic, async (raw) => {
+					try {
+						const message = JSON.parse(raw) as Message;
+						/* v8 ignore next -- @preserve */
+						const handlers = this.subscriptions.get(topic) ?? [];
+						await Promise.all(
+							handlers.map(async (sub) => sub.handler(message)),
+						);
+					} catch {
+						// Ignore malformed messages to prevent process crashes.
+					}
+				});
+			} catch (error) {
+				// Roll back the topic entry so a later retry re-subscribes
+				// instead of only appending a handler locally.
+				this.subscriptions.delete(topic);
+				throw error;
+			}
 		}
 
 		this.subscriptions.get(topic)?.push(handler);

--- a/packages/redis/src/task.ts
+++ b/packages/redis/src/task.ts
@@ -508,6 +508,7 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 							}
 						}
 					}, ttl);
+					timeoutHandle.unref();
 				} catch (error) {
 					this.emit("error", error);
 				}
@@ -530,6 +531,8 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 				}
 			}
 		}, timeout);
+		// Do not let a pending task timeout keep the process alive on its own.
+		timeoutHandle.unref();
 
 		try {
 			await handler.handler(task, context);

--- a/packages/redis/src/task.ts
+++ b/packages/redis/src/task.ts
@@ -320,8 +320,13 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 			const task = JSON.parse(taskDataStr) as Task;
 			const maxRetries = task.maxRetries ?? this._retries;
 
-			// Remove from processing
-			await client.zRem(this.getProcessingKey(queue), taskId);
+			// Remove from processing. If another instance already claimed this
+			// task, zRem returns 0 and we skip requeueing/dead-lettering it.
+			const removed = await client.zRem(this.getProcessingKey(queue), taskId);
+			/* v8 ignore next 3 -- @preserve */
+			if (removed === 0) {
+				continue;
+			}
 
 			// Remove from local processing set
 			this._processingTasks.get(queue)?.delete(taskId);
@@ -476,12 +481,18 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 					return;
 				}
 				try {
-					// Update deadline in processing set
+					// Update deadline in processing set. "XX" only updates the
+					// score if the task is still tracked, avoiding re-adding a
+					// task that already timed out and left the processing set.
 					const newDeadline = Date.now() + ttl;
-					await client.zAdd(this.getProcessingKey(queue), {
-						score: newDeadline,
-						value: task.id,
-					});
+					await client.zAdd(
+						this.getProcessingKey(queue),
+						{
+							score: newDeadline,
+							value: task.id,
+						},
+						{ XX: true },
+					);
 					// Reset timeout handle
 					/* v8 ignore start -- @preserve */
 					if (timeoutHandle) {

--- a/packages/redis/src/task.ts
+++ b/packages/redis/src/task.ts
@@ -38,10 +38,151 @@ export const defaultRetries = 3;
 export const defaultPollInterval = 1000;
 
 /**
+ * Atomically claims the next ready task. Pops the tail of the ready list and, if
+ * the task data still exists, records it in the processing set with a
+ * server-derived deadline, increments the attempt counter, and bumps the
+ * per-task fence token. Orphaned ids (task data already deleted) have their
+ * counters cleaned up and are skipped.
+ *
+ * KEYS[1] ready list, KEYS[2] processing zset.
+ * ARGV[1] per-task key prefix (`<queue>:task:`), ARGV[2] default timeout (ms).
+ * Returns nil when nothing claimable, else [taskId, taskJson, attempt, fence].
+ *
+ * The per-task keys are built from ARGV[1] because the id is unknown until RPOP;
+ * this is safe on standalone/Sentinel Redis/Valkey but not on Cluster.
+ */
+const CLAIM_SCRIPT = `
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+for _ = 1, 100 do
+	local id = redis.call('RPOP', KEYS[1])
+	if not id then
+		return nil
+	end
+	local data = redis.call('GET', ARGV[1] .. id)
+	if data then
+		local timeout = tonumber(ARGV[2])
+		local ok, task = pcall(cjson.decode, data)
+		if ok and type(task) == 'table' and type(task.timeout) == 'number' then
+			timeout = task.timeout
+		end
+		redis.call('ZADD', KEYS[2], now + timeout, id)
+		local attempt = redis.call('INCR', ARGV[1] .. id .. ':attempt')
+		local fence = redis.call('INCR', ARGV[1] .. id .. ':fence')
+		return { id, data, attempt, tostring(fence) }
+	end
+	redis.call('DEL', ARGV[1] .. id .. ':attempt', ARGV[1] .. id .. ':fence')
+end
+return nil
+`;
+
+/**
+ * Acknowledges (completes) a task, but only if this delivery still owns it.
+ *
+ * KEYS[1] processing zset, KEYS[2] task data, KEYS[3] attempt, KEYS[4] fence.
+ * ARGV[1] fence token, ARGV[2] taskId. Returns 1 if removed, 0 if stale.
+ */
+const ACK_SCRIPT = `
+if redis.call('GET', KEYS[4]) ~= ARGV[1] then
+	return 0
+end
+redis.call('ZREM', KEYS[1], ARGV[2])
+redis.call('DEL', KEYS[2], KEYS[3], KEYS[4])
+return 1
+`;
+
+/**
+ * Rejects a task, requeueing it for retry or moving it to the dead-letter queue,
+ * but only if this delivery still owns it. The fence token is consumed either
+ * way so no other holder of the token can act on the task afterwards.
+ *
+ * KEYS[1] processing, KEYS[2] ready, KEYS[3] dead-letter, KEYS[4] attempt,
+ * KEYS[5] fence. ARGV[1] token, ARGV[2] taskId, ARGV[3] "1"|"0" requeue flag,
+ * ARGV[4] maxRetries. Returns 1 if applied, 0 if stale.
+ */
+const REJECT_SCRIPT = `
+if redis.call('GET', KEYS[5]) ~= ARGV[1] then
+	return 0
+end
+redis.call('ZREM', KEYS[1], ARGV[2])
+local attempt = tonumber(redis.call('GET', KEYS[4]) or '0')
+if ARGV[3] == '1' and attempt < tonumber(ARGV[4]) then
+	redis.call('INCR', KEYS[5])
+	redis.call('LPUSH', KEYS[2], ARGV[2])
+else
+	redis.call('DEL', KEYS[5])
+	redis.call('LPUSH', KEYS[3], ARGV[2])
+end
+return 1
+`;
+
+/**
+ * Extends a task's visibility deadline, but only if this delivery still owns it.
+ * Uses XX (not GT) so extend() may legally shorten the deadline.
+ *
+ * KEYS[1] processing zset, KEYS[2] fence.
+ * ARGV[1] token, ARGV[2] taskId, ARGV[3] ttl (ms). Returns 1 if updated, 0 stale.
+ */
+const EXTEND_SCRIPT = `
+if redis.call('GET', KEYS[2]) ~= ARGV[1] then
+	return 0
+end
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('ZADD', KEYS[1], 'XX', now + tonumber(ARGV[3]), ARGV[2])
+return 1
+`;
+
+/**
+ * Recovers a timed-out task: re-checks expiry against the server clock, and if
+ * still expired removes it from processing, invalidates the stale owner's fence
+ * token, and requeues it (retries remaining) or dead-letters it. Mutates nothing
+ * when the task is no longer expired (a fresh delivery re-claimed it) or gone.
+ *
+ * KEYS[1] processing, KEYS[2] ready, KEYS[3] dead-letter, KEYS[4] attempt,
+ * KEYS[5] fence. ARGV[1] taskId, ARGV[2] maxRetries. Returns 1 if recovered.
+ */
+const RECOVER_SCRIPT = `
+local score = redis.call('ZSCORE', KEYS[1], ARGV[1])
+if not score then
+	return 0
+end
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+if tonumber(score) >= now then
+	return 0
+end
+redis.call('ZREM', KEYS[1], ARGV[1])
+local attempt = tonumber(redis.call('GET', KEYS[4]) or '0')
+if attempt < tonumber(ARGV[2]) then
+	redis.call('INCR', KEYS[5])
+	redis.call('LPUSH', KEYS[2], ARGV[1])
+else
+	redis.call('DEL', KEYS[5])
+	redis.call('LPUSH', KEYS[3], ARGV[1])
+end
+return 1
+`;
+
+/**
  * Redis-based task provider for Qified.
  * Uses Redis lists and sorted sets to enable reliable task queue processing
  * across multiple instances with visibility timeout, retries, and dead-letter queues.
  * Extends Hookified to emit events for errors and other lifecycle events.
+ *
+ * Distributed semantics:
+ * - Delivery is at-least-once: a handler that finishes right at its visibility
+ *   deadline can race recovery and run more than once, so handlers must be
+ *   idempotent.
+ * - Claim, acknowledge, reject, extend, and timeout-recovery run as atomic Lua
+ *   scripts. Each delivery carries a monotonic per-task fence token; an operation
+ *   from a delivery that has lost ownership (its token no longer matches) is a
+ *   no-op, so a stale worker cannot corrupt a newer delivery.
+ * - When several handlers are registered on one queue they share a single
+ *   delivery and token; the first acknowledgement or rejection decides the
+ *   outcome ("first finalizer wins").
+ * - Standalone/Sentinel only: the claim script builds per-task keys from a prefix
+ *   and the key schema is not Redis Cluster compatible.
  */
 export class RedisTaskProvider extends Hookified implements TaskProvider {
 	private _id: string;
@@ -53,7 +194,6 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 	private _active = true;
 	private _pollInterval: number;
 	private _pollTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
-	private _processingTasks: Map<string, Set<string>> = new Map();
 
 	/**
 	 * Creates a new Redis task provider instance.
@@ -195,6 +335,22 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 	}
 
 	/**
+	 * Gets the Redis key for the task fence token, used to detect stale
+	 * operations from a delivery that has lost ownership of the task.
+	 */
+	private getTaskFenceKey(queue: string, taskId: string): string {
+		return `${queue}:task:${taskId}:fence`;
+	}
+
+	/**
+	 * Gets the shared per-task key prefix (`<queue>:task:`) that the claim script
+	 * uses to build per-task keys from the popped task id.
+	 */
+	private getTaskKeyPrefix(queue: string): string {
+		return `${queue}:task:`;
+	}
+
+	/**
 	 * Enqueues a task to a specific queue.
 	 * @param queue The queue name to enqueue to
 	 * @param taskData The task data to enqueue
@@ -291,7 +447,9 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 		const client = await this.getClient();
 		const now = Date.now();
 
-		// Get tasks with deadline < now
+		// Advisory scan for tasks whose deadline has passed. RECOVER re-checks
+		// expiry against the server clock before acting, so a fast/slow local
+		// clock only affects recovery latency, never correctness.
 		const timedOutTasks = await client.zRangeByScore(
 			this.getProcessingKey(queue),
 			0,
@@ -303,41 +461,32 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 			if (!this._active) {
 				return;
 			}
-			// Get attempt count
-			const attemptStr = await client.get(
-				this.getTaskAttemptKey(queue, taskId),
-			);
-			const attempt = Number.parseInt(attemptStr ?? "0", 10);
 
-			// Get task data to check maxRetries
+			// Get task data to check maxRetries.
 			const taskDataStr = await client.get(this.getTaskDataKey(queue, taskId));
 			if (!taskDataStr) {
-				// Task data missing, clean up
+				// Task data missing; drop the orphaned processing entry and counters.
 				await client.zRem(this.getProcessingKey(queue), taskId);
+				await client.del(this.getTaskAttemptKey(queue, taskId));
+				await client.del(this.getTaskFenceKey(queue, taskId));
 				continue;
 			}
 
 			const task = JSON.parse(taskDataStr) as Task;
 			const maxRetries = task.maxRetries ?? this._retries;
 
-			// Remove from processing. If another instance already claimed this
-			// task, zRem returns 0 and we skip requeueing/dead-lettering it.
-			const removed = await client.zRem(this.getProcessingKey(queue), taskId);
-			/* v8 ignore next 3 -- @preserve */
-			if (removed === 0) {
-				continue;
-			}
-
-			// Remove from local processing set
-			this._processingTasks.get(queue)?.delete(taskId);
-
-			if (attempt < maxRetries) {
-				// Requeue for retry
-				await client.lPush(this.getQueueKey(queue), taskId);
-			} else {
-				// Move to dead-letter queue
-				await client.lPush(this.getDeadLetterKey(queue), taskId);
-			}
+			// Atomically recover the task: re-verify expiry, invalidate the stale
+			// owner's fence token, and requeue or dead-letter it.
+			await client.eval(RECOVER_SCRIPT, {
+				keys: [
+					this.getProcessingKey(queue),
+					this.getQueueKey(queue),
+					this.getDeadLetterKey(queue),
+					this.getTaskAttemptKey(queue, taskId),
+					this.getTaskFenceKey(queue, taskId),
+				],
+				arguments: [taskId, String(maxRetries)],
+			});
 		}
 	}
 
@@ -362,51 +511,32 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 			return;
 		}
 
-		// Initialize processing set for this queue if needed
-		if (!this._processingTasks.has(queue)) {
-			this._processingTasks.set(queue, new Set());
-		}
-
-		/* v8 ignore next -- @preserve */
-		const processingSet = this._processingTasks.get(queue) ?? new Set<string>();
-
-		// Get task from queue
-		let taskId: string | null;
+		// Atomically claim the next task (RPOP ready + ZADD processing + bump
+		// attempt and fence) so a crash can never leave it in neither structure.
+		let reply: [string, string, number, string] | null;
 		try {
-			taskId = await client.rPop(this.getQueueKey(queue));
+			reply = (await client.eval(CLAIM_SCRIPT, {
+				keys: [this.getQueueKey(queue), this.getProcessingKey(queue)],
+				arguments: [this.getTaskKeyPrefix(queue), String(this._timeout)],
+			})) as unknown as [string, string, number, string] | null;
 		} catch (error) {
 			/* v8 ignore start -- @preserve */
 			this.emit("error", error);
 			return;
 			/* v8 ignore stop */
 		}
-		if (!taskId) {
+
+		if (!reply) {
 			return;
 		}
 
-		// Check if already being processed locally
-		/* v8 ignore next 4 -- @preserve */
-		if (processingSet.has(taskId)) {
-			// Put back in queue and return
-			await client.lPush(this.getQueueKey(queue), taskId);
-			return;
-		}
-
-		// Get task data
-		const taskDataStr = await client.get(this.getTaskDataKey(queue, taskId));
-		if (!taskDataStr) {
-			// Task data missing, skip
-			return;
-		}
-
+		const [, taskDataStr, attempt, token] = reply;
 		const task = JSON.parse(taskDataStr) as Task;
 
-		// Mark as processing locally
-		processingSet.add(taskId);
-
-		// Process with each handler
+		// Process with each handler. They share one delivery and fence token;
+		// the first ack/reject wins.
 		for (const handler of handlers) {
-			void this.processTask(queue, task, handler);
+			void this.processTask(queue, task, handler, attempt, token);
 		}
 
 		// Continue processing more tasks
@@ -420,20 +550,12 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 		queue: string,
 		task: Task,
 		handler: TaskHandler,
+		attempt: number,
+		token: string,
 	): Promise<void> {
 		const client = await this.getClient();
 		const maxRetries = task.maxRetries ?? this._retries;
 		const timeout = task.timeout ?? this._timeout;
-
-		// Increment attempt count
-		const attempt = await client.incr(this.getTaskAttemptKey(queue, task.id));
-
-		// Add to processing sorted set with deadline
-		const deadline = Date.now() + timeout;
-		await client.zAdd(this.getProcessingKey(queue), {
-			score: deadline,
-			value: task.id,
-		});
 
 		let acknowledged = false;
 		let rejected = false;
@@ -447,7 +569,7 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 				}
 				acknowledged = true;
 				try {
-					await this.removeTask(queue, task.id);
+					await this.removeTask(queue, task.id, token);
 				} catch (error) {
 					/* v8 ignore next -- @preserve */
 					this.emit("error", error);
@@ -460,17 +582,23 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 				rejected = true;
 
 				try {
-					// Remove from processing
-					await client.zRem(this.getProcessingKey(queue), task.id);
-					this._processingTasks.get(queue)?.delete(task.id);
-
-					if (requeue && attempt < maxRetries) {
-						// Requeue for retry
-						await client.lPush(this.getQueueKey(queue), task.id);
-					} else {
-						// Move to dead-letter queue
-						await client.lPush(this.getDeadLetterKey(queue), task.id);
-					}
+					// Remove from processing and requeue or dead-letter, but only
+					// if this delivery still owns the task (fence token matches).
+					await client.eval(REJECT_SCRIPT, {
+						keys: [
+							this.getProcessingKey(queue),
+							this.getQueueKey(queue),
+							this.getDeadLetterKey(queue),
+							this.getTaskAttemptKey(queue, task.id),
+							this.getTaskFenceKey(queue, task.id),
+						],
+						arguments: [
+							token,
+							task.id,
+							requeue ? "1" : "0",
+							String(maxRetries),
+						],
+					});
 				} catch (error) {
 					/* v8 ignore next -- @preserve */
 					this.emit("error", error);
@@ -481,18 +609,14 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 					return;
 				}
 				try {
-					// Update deadline in processing set. "XX" only updates the
-					// score if the task is still tracked, avoiding re-adding a
-					// task that already timed out and left the processing set.
-					const newDeadline = Date.now() + ttl;
-					await client.zAdd(
-						this.getProcessingKey(queue),
-						{
-							score: newDeadline,
-							value: task.id,
-						},
-						{ XX: true },
-					);
+					// Extend the deadline only if this delivery still owns the task.
+					await client.eval(EXTEND_SCRIPT, {
+						keys: [
+							this.getProcessingKey(queue),
+							this.getTaskFenceKey(queue, task.id),
+						],
+						arguments: [token, task.id, String(ttl)],
+					});
 					// Reset timeout handle
 					/* v8 ignore start -- @preserve */
 					if (timeoutHandle) {
@@ -556,22 +680,25 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 	}
 
 	/**
-	 * Removes a task completely (on successful ack).
+	 * Removes a task completely (on successful ack), if this delivery still owns
+	 * it. A stale acknowledgement whose fence token no longer matches is a no-op.
 	 */
-	private async removeTask(queue: string, taskId: string): Promise<void> {
+	private async removeTask(
+		queue: string,
+		taskId: string,
+		token: string,
+	): Promise<void> {
 		const client = await this.getClient();
 
-		// Remove from processing set
-		await client.zRem(this.getProcessingKey(queue), taskId);
-
-		// Remove task data
-		await client.del(this.getTaskDataKey(queue, taskId));
-
-		// Remove attempt counter
-		await client.del(this.getTaskAttemptKey(queue, taskId));
-
-		// Remove from local processing set
-		this._processingTasks.get(queue)?.delete(taskId);
+		await client.eval(ACK_SCRIPT, {
+			keys: [
+				this.getProcessingKey(queue),
+				this.getTaskDataKey(queue, taskId),
+				this.getTaskAttemptKey(queue, taskId),
+				this.getTaskFenceKey(queue, taskId),
+			],
+			arguments: [token, taskId],
+		});
 	}
 
 	/**
@@ -620,7 +747,6 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 
 		// Clear handlers
 		this._taskHandlers.clear();
-		this._processingTasks.clear();
 
 		// Disconnect from Redis
 		if (this._connectionPromise) {
@@ -702,10 +828,11 @@ export class RedisTaskProvider extends Hookified implements TaskProvider {
 
 		const allTaskIds = [...queueTasks, ...processingTasks, ...deadLetterTasks];
 
-		// Delete all task data and attempt counters
+		// Delete all task data, attempt, and fence keys
 		for (const taskId of allTaskIds) {
 			await client.del(this.getTaskDataKey(queue, taskId));
 			await client.del(this.getTaskAttemptKey(queue, taskId));
+			await client.del(this.getTaskFenceKey(queue, taskId));
 		}
 
 		// Clear all queue structures

--- a/packages/redis/test/index.test.ts
+++ b/packages/redis/test/index.test.ts
@@ -125,6 +125,33 @@ describe("RedisMessageProvider", () => {
 		await provider.disconnect();
 	});
 
+	test("should roll back topic state when subscribe fails", async () => {
+		const provider = new RedisMessageProvider({
+			uri: "redis://localhost:9999",
+		});
+		await expect(
+			provider.subscribe("test-topic", { async handler() {} }),
+		).rejects.toThrow();
+		// The topic entry must not linger, or a later retry would skip the real
+		// subscribe and never receive messages.
+		expect(provider.subscriptions.has("test-topic")).toBe(false);
+	});
+
+	test("should not crash when a handler rejects", async () => {
+		const provider = new RedisMessageProvider();
+		await provider.subscribe("test-topic", {
+			async handler() {
+				throw new Error("handler failure");
+			},
+		});
+		await provider.publish("test-topic", { id: "1", data: "test" });
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+		await provider.disconnect();
+		expect(provider.subscriptions.size).toBe(0);
+	});
+
 	test("should get provider id", () => {
 		const provider = new RedisMessageProvider();
 		expect(provider.id).toBe(defaultRedisId);

--- a/packages/redis/test/index.test.ts
+++ b/packages/redis/test/index.test.ts
@@ -103,6 +103,28 @@ describe("RedisMessageProvider", () => {
 		expect(qified.messageProviders[0]).toBeInstanceOf(RedisMessageProvider);
 	});
 
+	test("should ignore malformed messages without crashing", async () => {
+		const provider = new RedisMessageProvider();
+		let received: Message | undefined;
+		await provider.subscribe("test-topic", {
+			async handler(message) {
+				received = message;
+			},
+		});
+		// Publish a raw, non-JSON payload directly on the channel to exercise the
+		// parse-error path in the subscriber's message listener.
+		const { pub } = provider as unknown as {
+			pub: { publish(channel: string, message: string): Promise<number> };
+		};
+		await pub.publish("test-topic", "not-json{");
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+		expect(received).toBeUndefined();
+
+		await provider.disconnect();
+	});
+
 	test("should get provider id", () => {
 		const provider = new RedisMessageProvider();
 		expect(provider.id).toBe(defaultRedisId);

--- a/packages/redis/test/task.test.ts
+++ b/packages/redis/test/task.test.ts
@@ -1511,4 +1511,256 @@ describe("RedisTaskProvider", () => {
 			await customProvider.disconnect();
 		});
 	});
+
+	describe("fencing and distributed safety", () => {
+		test("should ignore a stale ack after the fence token changes", async () => {
+			const customProvider = new RedisTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task, ctx: TaskContext) => {
+					// Simulate another worker re-claiming the task by bumping the
+					// fence, making this delivery's token stale, then ack.
+					await client.incr(`${testQueue}:task:${task.id}:fence`);
+					await ctx.ack();
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			const taskId = await customProvider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// The stale ack must not delete the task or drop the processing entry.
+			expect(await client.get(`${testQueue}:task:${taskId}`)).not.toBeNull();
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats.processing).toBe(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should ignore a stale reject after the fence token changes", async () => {
+			const customProvider = new RedisTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task, ctx: TaskContext) => {
+					await client.incr(`${testQueue}:task:${task.id}:fence`);
+					await ctx.reject(false);
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			const taskId = await customProvider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// The stale reject must not move the task to the dead-letter queue.
+			const dlq = await customProvider.getDeadLetterTasks(testQueue);
+			expect(dlq.length).toBe(0);
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats.processing).toBe(1);
+			expect(await client.get(`${testQueue}:task:${taskId}`)).not.toBeNull();
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should ignore a stale extend after the fence token changes", async () => {
+			const customProvider = new RedisTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			let completed = false;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task, ctx: TaskContext) => {
+					const before = await client.zScore(
+						`${testQueue}:processing`,
+						task.id,
+					);
+					await client.incr(`${testQueue}:task:${task.id}:fence`);
+					await ctx.extend(120000);
+					const after = await client.zScore(`${testQueue}:processing`, task.id);
+					// A stale extend must not move the deadline.
+					expect(after).toBe(before);
+					completed = true;
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			expect(completed).toBe(true);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should let the first finalizer win across multiple handlers", async () => {
+			const customProvider = new RedisTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const handlerA: TaskHandler = {
+				id: "handler-a",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.ack();
+				},
+			};
+			const handlerB: TaskHandler = {
+				id: "handler-b",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					// Finish after A has already finalized; this reject is fenced out.
+					await new Promise((resolve) => setTimeout(resolve, 80));
+					await ctx.reject(false);
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handlerA);
+			await customProvider.dequeue(testQueue, handlerB);
+			const taskId = await customProvider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 250));
+
+			const dlq = await customProvider.getDeadLetterTasks(testQueue);
+			expect(dlq.length).toBe(0);
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats).toEqual({ waiting: 0, processing: 0, deadLetter: 0 });
+			expect(await client.exists(`${testQueue}:task:${taskId}`)).toBe(0);
+			expect(await client.exists(`${testQueue}:task:${taskId}:fence`)).toBe(0);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should recover a timed-out task and invalidate the stale owner", async () => {
+			const customProvider = new RedisTaskProvider({
+				pollInterval: 25,
+				retries: 3,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const taskId = "recover-task";
+			await client.set(
+				`${testQueue}:task:${taskId}`,
+				JSON.stringify({ id: taskId, data: { message: "test" } }),
+			);
+			await client.set(`${testQueue}:task:${taskId}:attempt`, "0");
+			await client.set(`${testQueue}:task:${taskId}:fence`, "1");
+			// Already-expired processing entry owned by a now-dead worker.
+			await client.zAdd(`${testQueue}:processing`, {
+				score: Date.now() - 1000,
+				value: taskId,
+			});
+
+			let seenAttempt: number | undefined;
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					seenAttempt = ctx.metadata.attempt;
+					await ctx.ack();
+				},
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			// RECOVER requeued it (attempt 0 < 3); CLAIM re-delivered as attempt 1.
+			expect(seenAttempt).toBe(1);
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats).toEqual({ waiting: 0, processing: 0, deadLetter: 0 });
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should clean up counters for orphaned task ids on claim", async () => {
+			const customProvider = new RedisTaskProvider({ pollInterval: 60000 });
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			// A ready id whose task data was deleted, with leftover counters.
+			await client.set(`${testQueue}:task:orphan-task-id:attempt`, "5");
+			await client.set(`${testQueue}:task:orphan-task-id:fence`, "7");
+			await client.lPush(`${testQueue}:tasks`, "orphan-task-id");
+
+			let handlerCalled = false;
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {
+					handlerCalled = true;
+				},
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			expect(handlerCalled).toBe(false);
+			expect(
+				await client.exists(`${testQueue}:task:orphan-task-id:attempt`),
+			).toBe(0);
+			expect(
+				await client.exists(`${testQueue}:task:orphan-task-id:fence`),
+			).toBe(0);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should remove fence keys on clearQueue", async () => {
+			const customProvider = new RedisTaskProvider();
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const taskId = "fence-task";
+			await client.set(
+				`${testQueue}:task:${taskId}`,
+				JSON.stringify({ id: taskId, data: {} }),
+			);
+			await client.set(`${testQueue}:task:${taskId}:attempt`, "1");
+			await client.set(`${testQueue}:task:${taskId}:fence`, "1");
+			await client.zAdd(`${testQueue}:processing`, {
+				score: Date.now() + 60000,
+				value: taskId,
+			});
+
+			expect(await client.exists(`${testQueue}:task:${taskId}:fence`)).toBe(1);
+			await customProvider.clearQueue(testQueue);
+			expect(await client.exists(`${testQueue}:task:${taskId}:fence`)).toBe(0);
+
+			await customProvider.disconnect();
+		});
+	});
 });

--- a/packages/valkey/README.md
+++ b/packages/valkey/README.md
@@ -1,0 +1,99 @@
+# @qified/valkey
+
+Valkey message provider for [Qified](https://github.com/jaredwray/qified).
+
+This package implements a message provider backed by [Valkey](https://valkey.io) using the Valkey `publish`/`subscribe` commands. It is built on the [`iovalkey`](https://github.com/valkey-io/iovalkey) client and, because Valkey is wire-compatible with Redis, connects using `redis://` URIs.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage with Qified](#usage-with-qified)
+- [API](#api)
+  - [ValkeyMessageProviderOptions](#valkeymessageprovideroptions)
+  - [defaultValkeyUri](#defaultvalkeyuri)
+  - [ValkeyMessageProvider](#valkeymessageprovider)
+    - [constructor](#constructor)
+    - [publish](#publish)
+    - [subscribe](#subscribe)
+    - [unsubscribe](#unsubscribe)
+    - [disconnect](#disconnect)
+  - [createQified](#createqified)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Installation
+
+```bash
+pnpm add @qified/valkey
+```
+
+## Usage with Qified
+
+```ts
+import { createQified } from "@qified/valkey";
+import type { Message } from "qified";
+
+const qified = createQified({ uri: "redis://localhost:6380" });
+
+await qified.subscribe("example-topic", {
+        async handler(message: Message) {
+                console.log(message);
+        },
+});
+
+await qified.publish("example-topic", { id: "1", data: "Hello from Valkey!" });
+
+await qified.disconnect();
+```
+
+## API
+
+### ValkeyMessageProviderOptions
+
+Configuration options for the Valkey message provider.
+
+- `uri?`: Valkey connection URI. Defaults to [`defaultValkeyUri`](#defaultvalkeyuri).
+
+### defaultValkeyUri
+
+Default Valkey connection string (`"redis://localhost:6380"`).
+
+### ValkeyMessageProvider
+
+Implements the `MessageProvider` interface using Valkey pub/sub.
+
+#### constructor(options?: ValkeyMessageProviderOptions)
+
+Creates a new provider.
+
+Options:
+
+- `uri`: Valkey connection URI (defaults to `"redis://localhost:6380"`).
+
+#### publish(topic: string, message: Message)
+
+Publishes a message to a topic.
+
+#### subscribe(topic: string, handler: TopicHandler)
+
+Subscribes a handler to a topic.
+
+#### unsubscribe(topic: string, id?: string)
+
+Unsubscribes a handler by id or all handlers for a topic.
+
+#### disconnect()
+
+Disconnects the underlying Valkey clients and clears all subscriptions.
+
+### createQified(options?: ValkeyMessageProviderOptions)
+
+Convenience factory that returns a `Qified` instance configured with `ValkeyMessageProvider`.
+
+## Contributing
+
+Contributions are welcome! Please read the [CONTRIBUTING.md](../../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md) for details on our process.
+
+## License
+
+MIT © Jared Wray. See [LICENSE](../../LICENSE) for details.

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@qified/valkey",
+  "version": "0.12.0",
+  "description": "Valkey message provider for qified",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "lint": "biome check --write --error-on-warnings",
+    "test": "pnpm lint && vitest run --coverage",
+    "test:ci": "biome check --error-on-warnings && vitest run --coverage",
+    "clean": "rimraf ./dist ./coverage",
+    "build": "tsdown src/index.ts --format esm --format cjs --dts",
+    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
+    "prepublishOnly": "pnpm build"
+  },
+  "keywords": [
+    "qified",
+    "valkey",
+    "message",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jaredwray/qified.git",
+    "directory": "packages/valkey"
+  },
+  "author": "Jared Wray <me@jaredwray.com>",
+  "license": "MIT",
+  "dependencies": {
+    "hookified": "^3.0.0",
+    "iovalkey": "^0.3.3"
+  },
+  "peerDependencies": {
+    "qified": "workspace:^"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
+}

--- a/packages/valkey/src/index.ts
+++ b/packages/valkey/src/index.ts
@@ -62,10 +62,14 @@ export class ValkeyMessageProvider implements MessageProvider {
 		// The subscriber connection delivers every channel's messages through a
 		// single "message" event, so wire the listener once and route by channel.
 		this.sub.on("message", (channel: string, raw: string) => {
-			const message = JSON.parse(raw) as Message;
-			/* v8 ignore next -- @preserve */
-			const handlers = this.subscriptions.get(channel) ?? [];
-			void Promise.all(handlers.map(async (sub) => sub.handler(message)));
+			try {
+				const message = JSON.parse(raw) as Message;
+				/* v8 ignore next -- @preserve */
+				const handlers = this.subscriptions.get(channel) ?? [];
+				void Promise.all(handlers.map(async (sub) => sub.handler(message)));
+			} catch {
+				// Ignore malformed messages to prevent process crashes.
+			}
 		});
 	}
 

--- a/packages/valkey/src/index.ts
+++ b/packages/valkey/src/index.ts
@@ -1,0 +1,231 @@
+import { Redis } from "iovalkey";
+import {
+	type Message,
+	type MessageProvider,
+	Qified,
+	type TopicHandler,
+} from "qified";
+
+export {
+	defaultPollInterval,
+	defaultRetries as defaultTaskRetries,
+	defaultTimeout as defaultTaskTimeout,
+	defaultValkeyTaskId,
+	ValkeyTaskProvider,
+	type ValkeyTaskProviderOptions,
+} from "./task.js";
+
+/**
+ * Configuration options for the Valkey message provider.
+ */
+export type ValkeyMessageProviderOptions = {
+	/** Valkey connection URI. Defaults to "redis://localhost:6380" */
+	uri?: string;
+	/** Unique identifier for this provider instance. Defaults to "@qified/valkey" */
+	id?: string;
+};
+
+/** Default Valkey connection URI */
+export const defaultValkeyUri = "redis://localhost:6380";
+
+/** Default Valkey provider identifier */
+export const defaultValkeyId = "@qified/valkey";
+
+/**
+ * Valkey-based message provider for Qified.
+ * Uses Valkey pub/sub to enable message distribution across multiple instances.
+ */
+export class ValkeyMessageProvider implements MessageProvider {
+	/** Map of topic names to their registered handlers */
+	public subscriptions = new Map<string, TopicHandler[]>();
+
+	/** Valkey client used for publishing messages */
+	private readonly pub: Redis;
+
+	/** Valkey client used for subscribing to messages */
+	private readonly sub: Redis;
+
+	/** Connection promise to ensure connect is only called once */
+	private connectionPromise: Promise<void> | null = null;
+
+	private _id: string;
+
+	/**
+	 * Creates a new Valkey message provider instance.
+	 * @param options Configuration options for the provider
+	 */
+	constructor(options: ValkeyMessageProviderOptions = {}) {
+		const uri = options.uri ?? defaultValkeyUri;
+		this._id = options.id ?? defaultValkeyId;
+		this.pub = new Redis(uri, { lazyConnect: true });
+		this.sub = this.pub.duplicate();
+		// The subscriber connection delivers every channel's messages through a
+		// single "message" event, so wire the listener once and route by channel.
+		this.sub.on("message", (channel: string, raw: string) => {
+			const message = JSON.parse(raw) as Message;
+			/* v8 ignore next -- @preserve */
+			const handlers = this.subscriptions.get(channel) ?? [];
+			void Promise.all(handlers.map(async (sub) => sub.handler(message)));
+		});
+	}
+
+	/**
+	 * Connects to Valkey. Can be called explicitly or will be called automatically on first use.
+	 * @throws Error if connection fails
+	 */
+	async connect(): Promise<void> {
+		if (!this.connectionPromise) {
+			this.connectionPromise = (async () => {
+				try {
+					await this.pub.connect();
+					await this.sub.connect();
+				} catch (error) {
+					this.connectionPromise = null;
+					// Stop the default reconnect loop so a failed connection does not
+					// leave background retry timers running.
+					this.pub.disconnect();
+					this.sub.disconnect();
+					throw error;
+				}
+			})();
+		}
+		return this.connectionPromise;
+	}
+
+	/**
+	 * Returns the connected publish client, connecting if necessary.
+	 * @private
+	 */
+	private async getPubClient(): Promise<Redis> {
+		await this.connect();
+		return this.pub;
+	}
+
+	/**
+	 * Returns the connected subscribe client, connecting if necessary.
+	 * @private
+	 */
+	private async getSubClient(): Promise<Redis> {
+		await this.connect();
+		return this.sub;
+	}
+
+	/**
+	 * Gets the unique identifier for this provider instance.
+	 */
+	public get id(): string {
+		return this._id;
+	}
+
+	/**
+	 * Sets the unique identifier for this provider instance.
+	 */
+	public set id(id: string) {
+		this._id = id;
+	}
+
+	/**
+	 * Publishes a message to a specific topic.
+	 * @param topic The topic to publish to
+	 * @param message The message to publish
+	 */
+	async publish(
+		topic: string,
+		message: Omit<Message, "providerId">,
+	): Promise<void> {
+		const messageWithProvider: Message = {
+			...message,
+			providerId: this._id,
+		};
+		const pubClient = await this.getPubClient();
+		await pubClient.publish(topic, JSON.stringify(messageWithProvider));
+	}
+
+	/**
+	 * Subscribes to a topic with a handler function.
+	 * @param topic The topic to subscribe to
+	 * @param handler The handler function to call when messages are received
+	 */
+	async subscribe(topic: string, handler: TopicHandler): Promise<void> {
+		if (!this.subscriptions.has(topic)) {
+			this.subscriptions.set(topic, []);
+			const subClient = await this.getSubClient();
+			await subClient.subscribe(topic);
+		}
+
+		this.subscriptions.get(topic)?.push(handler);
+	}
+
+	/**
+	 * Unsubscribes from a topic, either for a specific handler or all handlers.
+	 * @param topic The topic to unsubscribe from
+	 * @param id Optional handler ID. If provided, only that handler is removed. Otherwise, all handlers are removed.
+	 */
+	async unsubscribe(topic: string, id?: string): Promise<void> {
+		if (id) {
+			const current = this.subscriptions.get(topic);
+			/* v8 ignore next -- @preserve */
+			if (current) {
+				this.subscriptions.set(
+					topic,
+					current.filter((sub) => sub.id !== id),
+				);
+			}
+		} else {
+			this.subscriptions.delete(topic);
+			const subClient = await this.getSubClient();
+			await subClient.unsubscribe(topic);
+		}
+	}
+
+	/**
+	 * Disconnects from Valkey, unsubscribing from all topics and closing connections.
+	 * @param force If true, forcefully terminates the connection without sending a quit command. Defaults to false.
+	 */
+	async disconnect(force = false): Promise<void> {
+		// Only disconnect if we've connected
+		/* v8 ignore next -- @preserve */
+		if (this.connectionPromise) {
+			await this.connectionPromise;
+
+			const topics = [...this.subscriptions.keys()];
+			if (topics.length > 0) {
+				await this.sub.unsubscribe(...topics);
+			}
+
+			this.subscriptions.clear();
+
+			/* v8 ignore start -- @preserve */
+			if (force) {
+				if (this.pub.status !== "end") {
+					this.pub.disconnect();
+				}
+
+				if (this.sub.status !== "end") {
+					this.sub.disconnect();
+				}
+			} else {
+				if (this.pub.status === "ready") {
+					await this.pub.quit();
+				}
+
+				if (this.sub.status === "ready") {
+					await this.sub.quit();
+				}
+			}
+			/* v8 ignore stop */
+
+			this.connectionPromise = null;
+		}
+	}
+}
+
+/**
+ * Creates a new instance of Qified with a Valkey message provider.
+ * @param {ValkeyMessageProviderOptions} options Optional configuration for the Valkey message provider.
+ * @returns A new instance of Qified.
+ */
+export function createQified(options?: ValkeyMessageProviderOptions): Qified {
+	const provider = new ValkeyMessageProvider(options);
+	return new Qified({ messageProviders: [provider] });
+}

--- a/packages/valkey/src/index.ts
+++ b/packages/valkey/src/index.ts
@@ -66,7 +66,11 @@ export class ValkeyMessageProvider implements MessageProvider {
 				const message = JSON.parse(raw) as Message;
 				/* v8 ignore next -- @preserve */
 				const handlers = this.subscriptions.get(channel) ?? [];
-				void Promise.all(handlers.map(async (sub) => sub.handler(message)));
+				void Promise.all(
+					handlers.map(async (sub) => sub.handler(message)),
+				).catch(() => {
+					// Ignore handler failures to prevent unhandled rejections.
+				});
 			} catch {
 				// Ignore malformed messages to prevent process crashes.
 			}
@@ -153,8 +157,15 @@ export class ValkeyMessageProvider implements MessageProvider {
 	async subscribe(topic: string, handler: TopicHandler): Promise<void> {
 		if (!this.subscriptions.has(topic)) {
 			this.subscriptions.set(topic, []);
-			const subClient = await this.getSubClient();
-			await subClient.subscribe(topic);
+			try {
+				const subClient = await this.getSubClient();
+				await subClient.subscribe(topic);
+			} catch (error) {
+				// Roll back the topic entry so a later retry re-subscribes
+				// instead of only appending a handler locally.
+				this.subscriptions.delete(topic);
+				throw error;
+			}
 		}
 
 		this.subscriptions.get(topic)?.push(handler);

--- a/packages/valkey/src/task.ts
+++ b/packages/valkey/src/task.ts
@@ -1,0 +1,706 @@
+import { randomUUID } from "node:crypto";
+import { Hookified } from "hookified";
+import { Redis } from "iovalkey";
+import type {
+	EnqueueTask,
+	Task,
+	TaskContext,
+	TaskHandler,
+	TaskProvider,
+	TaskProviderOptions,
+} from "qified";
+
+/**
+ * Configuration options for the Valkey task provider.
+ */
+export type ValkeyTaskProviderOptions = TaskProviderOptions & {
+	/** Valkey connection URI. Defaults to "redis://localhost:6380" */
+	uri?: string;
+	/** Unique identifier for this provider instance. Defaults to "@qified/valkey-task" */
+	id?: string;
+	/** Poll interval in milliseconds for checking timed-out tasks. Defaults to 1000 */
+	pollInterval?: number;
+};
+
+/** Default Valkey connection URI */
+export const defaultValkeyUri = "redis://localhost:6380";
+
+/** Default Valkey task provider identifier */
+export const defaultValkeyTaskId = "@qified/valkey-task";
+
+/** Default timeout for task processing (30 seconds) */
+export const defaultTimeout = 30000;
+
+/** Default maximum retry attempts */
+export const defaultRetries = 3;
+
+/** Default poll interval (1 second) */
+export const defaultPollInterval = 1000;
+
+/**
+ * Valkey-based task provider for Qified.
+ * Uses Valkey lists and sorted sets to enable reliable task queue processing
+ * across multiple instances with visibility timeout, retries, and dead-letter queues.
+ * Extends Hookified to emit events for errors and other lifecycle events.
+ */
+export class ValkeyTaskProvider extends Hookified implements TaskProvider {
+	private _id: string;
+	private _timeout: number;
+	private _retries: number;
+	private _taskHandlers: Map<string, TaskHandler[]>;
+	private _uri: string;
+	private _client: Redis;
+	private _connectionPromise: Promise<void> | null = null;
+	private _active = true;
+	private _pollInterval: number;
+	private _pollTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+	private _processingTasks: Map<string, Set<string>> = new Map();
+
+	/**
+	 * Creates a new Valkey task provider instance.
+	 * @param options Configuration options for the provider
+	 */
+	constructor(options: ValkeyTaskProviderOptions = {}) {
+		super();
+		const uri = options.uri ?? defaultValkeyUri;
+		this._id = options.id ?? defaultValkeyTaskId;
+		this._timeout = options.timeout ?? defaultTimeout;
+		this._retries = options.retries ?? defaultRetries;
+		this._pollInterval = options.pollInterval ?? defaultPollInterval;
+		this._taskHandlers = new Map();
+		this._uri = uri;
+		this._client = new Redis(uri, { lazyConnect: true });
+	}
+
+	/**
+	 * Gets the provider ID.
+	 */
+	public get id(): string {
+		return this._id;
+	}
+
+	/**
+	 * Sets the provider ID.
+	 */
+	public set id(id: string) {
+		this._id = id;
+	}
+
+	/**
+	 * Gets the default timeout for task processing.
+	 */
+	public get timeout(): number {
+		return this._timeout;
+	}
+
+	/**
+	 * Sets the default timeout for task processing.
+	 */
+	public set timeout(timeout: number) {
+		this._timeout = timeout;
+	}
+
+	/**
+	 * Gets the default maximum retry attempts.
+	 */
+	public get retries(): number {
+		return this._retries;
+	}
+
+	/**
+	 * Sets the default maximum retry attempts.
+	 */
+	public set retries(retries: number) {
+		this._retries = retries;
+	}
+
+	/**
+	 * Gets the task handlers map.
+	 */
+	public get taskHandlers(): Map<string, TaskHandler[]> {
+		return this._taskHandlers;
+	}
+
+	/**
+	 * Sets the task handlers map.
+	 */
+	public set taskHandlers(value: Map<string, TaskHandler[]>) {
+		this._taskHandlers = value;
+	}
+
+	/**
+	 * Connects to Valkey. Can be called explicitly or will be called automatically on first use.
+	 */
+	async connect(): Promise<void> {
+		if (!this._connectionPromise) {
+			this._connectionPromise = (async () => {
+				try {
+					// A Valkey client cannot be reopened once it has connected and
+					// closed, so use a fresh client whenever we are reconnecting.
+					if (this._client.status !== "wait") {
+						this._client = new Redis(this._uri, { lazyConnect: true });
+					}
+					await this._client.connect();
+				} catch (error) {
+					this._connectionPromise = null;
+					// Stop the default reconnect loop so a failed connection does not
+					// leave background retry timers running.
+					this._client.disconnect();
+					throw error;
+				}
+			})();
+		}
+		return this._connectionPromise;
+	}
+
+	/**
+	 * Returns the connected client, connecting if necessary.
+	 */
+	private async getClient(): Promise<Redis> {
+		await this.connect();
+		return this._client;
+	}
+
+	/**
+	 * Generates a globally unique task ID using UUID.
+	 * This ensures uniqueness across multiple ValkeyTaskProvider instances.
+	 */
+	private generateTaskId(): string {
+		return `task-${randomUUID()}`;
+	}
+
+	/**
+	 * Gets the Valkey key for the task queue list.
+	 */
+	private getQueueKey(queue: string): string {
+		return `${queue}:tasks`;
+	}
+
+	/**
+	 * Gets the Valkey key for processing tasks sorted set.
+	 */
+	private getProcessingKey(queue: string): string {
+		return `${queue}:processing`;
+	}
+
+	/**
+	 * Gets the Valkey key for dead-letter queue.
+	 */
+	private getDeadLetterKey(queue: string): string {
+		return `${queue}:dead-letter`;
+	}
+
+	/**
+	 * Gets the Valkey key for task data.
+	 */
+	private getTaskDataKey(queue: string, taskId: string): string {
+		return `${queue}:task:${taskId}`;
+	}
+
+	/**
+	 * Gets the Valkey key for task attempt count.
+	 */
+	private getTaskAttemptKey(queue: string, taskId: string): string {
+		return `${queue}:task:${taskId}:attempt`;
+	}
+
+	/**
+	 * Enqueues a task to a specific queue.
+	 * @param queue The queue name to enqueue to
+	 * @param taskData The task data to enqueue
+	 * @returns The ID of the enqueued task
+	 */
+	public async enqueue(queue: string, taskData: EnqueueTask): Promise<string> {
+		if (!this._active) {
+			throw new Error("TaskProvider has been disconnected");
+		}
+
+		const client = await this.getClient();
+
+		const task: Task = {
+			id: this.generateTaskId(),
+			timestamp: Date.now(),
+			...taskData,
+		};
+
+		// Store task data
+		await client.set(this.getTaskDataKey(queue, task.id), JSON.stringify(task));
+
+		// Initialize attempt count
+		await client.set(this.getTaskAttemptKey(queue, task.id), "0");
+
+		// Add to queue list (LPUSH for FIFO with RPOP)
+		await client.lpush(this.getQueueKey(queue), task.id);
+
+		// Process immediately if handlers are registered
+		void this.processQueue(queue);
+
+		return task.id;
+	}
+
+	/**
+	 * Registers a handler to process tasks from a queue.
+	 * @param queue The queue name to dequeue from
+	 * @param handler The handler configuration
+	 */
+	public async dequeue(queue: string, handler: TaskHandler): Promise<void> {
+		if (!this._active) {
+			throw new Error("TaskProvider has been disconnected");
+		}
+
+		if (!this._taskHandlers.has(queue)) {
+			this._taskHandlers.set(queue, []);
+		}
+
+		this._taskHandlers.get(queue)?.push(handler);
+
+		// Start polling for this queue if not already polling
+		if (!this._pollTimers.has(queue)) {
+			this.startPolling(queue);
+		}
+
+		// Process any pending tasks
+		await this.processQueue(queue);
+	}
+
+	/**
+	 * Starts the polling loop for a queue.
+	 */
+	private startPolling(queue: string): void {
+		const poll = async () => {
+			/* v8 ignore next -- @preserve */
+			if (!this._active) {
+				return;
+			}
+
+			try {
+				await this.checkTimedOutTasks(queue);
+				await this.processQueue(queue);
+			} catch (error) {
+				/* v8 ignore next -- @preserve */
+				this.emit("error", error);
+			}
+
+			if (this._active && this._taskHandlers.has(queue)) {
+				this._pollTimers.set(queue, setTimeout(poll, this._pollInterval));
+			}
+		};
+
+		this._pollTimers.set(queue, setTimeout(poll, this._pollInterval));
+	}
+
+	/**
+	 * Checks for tasks that have timed out during processing.
+	 */
+	private async checkTimedOutTasks(queue: string): Promise<void> {
+		/* v8 ignore next -- @preserve */
+		if (!this._active) {
+			return;
+		}
+
+		const client = await this.getClient();
+		const now = Date.now();
+
+		// Get tasks with deadline < now
+		const timedOutTasks = await client.zrangebyscore(
+			this.getProcessingKey(queue),
+			0,
+			now - 1,
+		);
+
+		for (const taskId of timedOutTasks) {
+			/* v8 ignore next -- @preserve */
+			if (!this._active) {
+				return;
+			}
+			// Get attempt count
+			const attemptStr = await client.get(
+				this.getTaskAttemptKey(queue, taskId),
+			);
+			const attempt = Number.parseInt(attemptStr ?? "0", 10);
+
+			// Get task data to check maxRetries
+			const taskDataStr = await client.get(this.getTaskDataKey(queue, taskId));
+			if (!taskDataStr) {
+				// Task data missing, clean up
+				await client.zrem(this.getProcessingKey(queue), taskId);
+				continue;
+			}
+
+			const task = JSON.parse(taskDataStr) as Task;
+			const maxRetries = task.maxRetries ?? this._retries;
+
+			// Remove from processing
+			await client.zrem(this.getProcessingKey(queue), taskId);
+
+			// Remove from local processing set
+			this._processingTasks.get(queue)?.delete(taskId);
+
+			if (attempt < maxRetries) {
+				// Requeue for retry
+				await client.lpush(this.getQueueKey(queue), taskId);
+			} else {
+				// Move to dead-letter queue
+				await client.lpush(this.getDeadLetterKey(queue), taskId);
+			}
+		}
+	}
+
+	/**
+	 * Processes tasks in a queue by delivering them to registered handlers.
+	 */
+	private async processQueue(queue: string): Promise<void> {
+		/* v8 ignore next -- @preserve */
+		if (!this._active) {
+			return;
+		}
+
+		const handlers = this._taskHandlers.get(queue);
+		if (!handlers || handlers.length === 0) {
+			return;
+		}
+
+		const client = await this.getClient();
+
+		// Check again after async operation
+		if (!this._active) {
+			return;
+		}
+
+		// Initialize processing set for this queue if needed
+		if (!this._processingTasks.has(queue)) {
+			this._processingTasks.set(queue, new Set());
+		}
+
+		/* v8 ignore next -- @preserve */
+		const processingSet = this._processingTasks.get(queue) ?? new Set<string>();
+
+		// Get task from queue
+		let taskId: string | null;
+		try {
+			taskId = await client.rpop(this.getQueueKey(queue));
+		} catch (error) {
+			/* v8 ignore start -- @preserve */
+			this.emit("error", error);
+			return;
+			/* v8 ignore stop */
+		}
+		if (!taskId) {
+			return;
+		}
+
+		// Check if already being processed locally
+		/* v8 ignore next 4 -- @preserve */
+		if (processingSet.has(taskId)) {
+			// Put back in queue and return
+			await client.lpush(this.getQueueKey(queue), taskId);
+			return;
+		}
+
+		// Get task data
+		const taskDataStr = await client.get(this.getTaskDataKey(queue, taskId));
+		if (!taskDataStr) {
+			// Task data missing, skip
+			return;
+		}
+
+		const task = JSON.parse(taskDataStr) as Task;
+
+		// Mark as processing locally
+		processingSet.add(taskId);
+
+		// Process with each handler
+		for (const handler of handlers) {
+			void this.processTask(queue, task, handler);
+		}
+
+		// Continue processing more tasks
+		void this.processQueue(queue);
+	}
+
+	/**
+	 * Processes a single task with a handler.
+	 */
+	private async processTask(
+		queue: string,
+		task: Task,
+		handler: TaskHandler,
+	): Promise<void> {
+		const client = await this.getClient();
+		const maxRetries = task.maxRetries ?? this._retries;
+		const timeout = task.timeout ?? this._timeout;
+
+		// Increment attempt count
+		const attempt = await client.incr(this.getTaskAttemptKey(queue, task.id));
+
+		// Add to processing sorted set with deadline
+		const deadline = Date.now() + timeout;
+		await client.zadd(this.getProcessingKey(queue), deadline, task.id);
+
+		let acknowledged = false;
+		let rejected = false;
+		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+		// Create task context
+		const context: TaskContext = {
+			ack: async () => {
+				if (acknowledged || rejected || !this._active) {
+					return;
+				}
+				acknowledged = true;
+				try {
+					await this.removeTask(queue, task.id);
+				} catch (error) {
+					/* v8 ignore next -- @preserve */
+					this.emit("error", error);
+				}
+			},
+			reject: async (requeue = true) => {
+				if (acknowledged || rejected || !this._active) {
+					return;
+				}
+				rejected = true;
+
+				try {
+					// Remove from processing
+					await client.zrem(this.getProcessingKey(queue), task.id);
+					this._processingTasks.get(queue)?.delete(task.id);
+
+					if (requeue && attempt < maxRetries) {
+						// Requeue for retry
+						await client.lpush(this.getQueueKey(queue), task.id);
+					} else {
+						// Move to dead-letter queue
+						await client.lpush(this.getDeadLetterKey(queue), task.id);
+					}
+				} catch (error) {
+					/* v8 ignore next -- @preserve */
+					this.emit("error", error);
+				}
+			},
+			extend: async (ttl: number) => {
+				if (acknowledged || rejected || !this._active) {
+					return;
+				}
+				try {
+					// Update deadline in processing set
+					const newDeadline = Date.now() + ttl;
+					await client.zadd(this.getProcessingKey(queue), newDeadline, task.id);
+					// Reset timeout handle
+					/* v8 ignore start -- @preserve */
+					if (timeoutHandle) {
+						clearTimeout(timeoutHandle);
+					}
+					timeoutHandle = setTimeout(async () => {
+						if (!acknowledged && !rejected && this._active) {
+							try {
+								await context.reject(true);
+							} catch (error) {
+								/* v8 ignore next -- @preserve */
+								this.emit("error", error);
+							}
+						}
+					}, ttl);
+				} catch (error) {
+					this.emit("error", error);
+				}
+			},
+			metadata: {
+				attempt,
+				maxRetries,
+			},
+		};
+		/* v8 ignore stop */
+
+		// Set timeout handler
+		timeoutHandle = setTimeout(async () => {
+			if (!acknowledged && !rejected && this._active) {
+				try {
+					await context.reject(true);
+				} catch (error) {
+					/* v8 ignore next -- @preserve */
+					this.emit("error", error);
+				}
+			}
+		}, timeout);
+
+		try {
+			await handler.handler(task, context);
+
+			// Auto-ack if handler completes without explicit ack/reject
+			if (!acknowledged && !rejected) {
+				await context.ack();
+			}
+		} catch {
+			// Auto-reject on error
+			/* v8 ignore start -- @preserve */
+			if (!acknowledged && !rejected) {
+				await context.reject(true);
+			}
+		} finally {
+			if (timeoutHandle) {
+				clearTimeout(timeoutHandle);
+			}
+			/* v8 ignore stop */
+		}
+	}
+
+	/**
+	 * Removes a task completely (on successful ack).
+	 */
+	private async removeTask(queue: string, taskId: string): Promise<void> {
+		const client = await this.getClient();
+
+		// Remove from processing set
+		await client.zrem(this.getProcessingKey(queue), taskId);
+
+		// Remove task data
+		await client.del(this.getTaskDataKey(queue, taskId));
+
+		// Remove attempt counter
+		await client.del(this.getTaskAttemptKey(queue, taskId));
+
+		// Remove from local processing set
+		this._processingTasks.get(queue)?.delete(taskId);
+	}
+
+	/**
+	 * Unsubscribes a handler from a queue.
+	 * @param queue The queue name to unsubscribe from
+	 * @param id Optional handler ID. If not provided, removes all handlers.
+	 */
+	public async unsubscribe(queue: string, id?: string): Promise<void> {
+		if (id) {
+			const handlers = this._taskHandlers.get(queue);
+			if (handlers) {
+				this._taskHandlers.set(
+					queue,
+					handlers.filter((h) => h.id !== id),
+				);
+			}
+		} else {
+			this._taskHandlers.delete(queue);
+		}
+
+		// Stop polling if no handlers left for this queue
+		if (
+			!this._taskHandlers.has(queue) ||
+			this._taskHandlers.get(queue)?.length === 0
+		) {
+			const timer = this._pollTimers.get(queue);
+			if (timer) {
+				clearTimeout(timer);
+				this._pollTimers.delete(queue);
+			}
+		}
+	}
+
+	/**
+	 * Disconnects and cleans up the provider.
+	 * @param force If true, forcefully terminates the connection. Defaults to false.
+	 */
+	public async disconnect(force = false): Promise<void> {
+		this._active = false;
+
+		// Clear all poll timers
+		for (const timer of this._pollTimers.values()) {
+			clearTimeout(timer);
+		}
+		this._pollTimers.clear();
+
+		// Clear handlers
+		this._taskHandlers.clear();
+		this._processingTasks.clear();
+
+		// Disconnect from Valkey
+		if (this._connectionPromise) {
+			await this._connectionPromise;
+
+			if (force) {
+				this._client.disconnect();
+			} else {
+				try {
+					await this._client.quit();
+				} catch {
+					// The connection is already closing or closed; nothing to do.
+				}
+			}
+
+			this._connectionPromise = null;
+		}
+	}
+
+	/**
+	 * Gets all tasks in the dead-letter queue for a specific queue.
+	 * @param queue The queue name
+	 * @returns Array of tasks in the dead-letter queue
+	 */
+	public async getDeadLetterTasks(queue: string): Promise<Task[]> {
+		const client = await this.getClient();
+		const taskIds = await client.lrange(this.getDeadLetterKey(queue), 0, -1);
+
+		const tasks: Task[] = [];
+		for (const taskId of taskIds) {
+			const taskDataStr = await client.get(this.getTaskDataKey(queue, taskId));
+			/* v8 ignore next -- @preserve */
+			if (taskDataStr) {
+				tasks.push(JSON.parse(taskDataStr) as Task);
+			}
+		}
+
+		return tasks;
+	}
+
+	/**
+	 * Gets the current state of a queue.
+	 * @param queue The queue name
+	 * @returns Queue statistics
+	 */
+	public async getQueueStats(queue: string): Promise<{
+		waiting: number;
+		processing: number;
+		deadLetter: number;
+	}> {
+		const client = await this.getClient();
+
+		const [waiting, processing, deadLetter] = await Promise.all([
+			client.llen(this.getQueueKey(queue)),
+			client.zcard(this.getProcessingKey(queue)),
+			client.llen(this.getDeadLetterKey(queue)),
+		]);
+
+		return {
+			waiting,
+			processing,
+			deadLetter,
+		};
+	}
+
+	/**
+	 * Clears all data for a queue. Useful for testing.
+	 * @param queue The queue name to clear
+	 */
+	public async clearQueue(queue: string): Promise<void> {
+		const client = await this.getClient();
+
+		// Get all task IDs from all locations
+		const [queueTasks, processingTasks, deadLetterTasks] = await Promise.all([
+			client.lrange(this.getQueueKey(queue), 0, -1),
+			client.zrange(this.getProcessingKey(queue), 0, -1),
+			client.lrange(this.getDeadLetterKey(queue), 0, -1),
+		]);
+
+		const allTaskIds = [...queueTasks, ...processingTasks, ...deadLetterTasks];
+
+		// Delete all task data and attempt counters
+		for (const taskId of allTaskIds) {
+			await client.del(this.getTaskDataKey(queue, taskId));
+			await client.del(this.getTaskAttemptKey(queue, taskId));
+		}
+
+		// Clear all queue structures
+		await client.del(this.getQueueKey(queue));
+		await client.del(this.getProcessingKey(queue));
+		await client.del(this.getDeadLetterKey(queue));
+	}
+}

--- a/packages/valkey/src/task.ts
+++ b/packages/valkey/src/task.ts
@@ -38,10 +38,151 @@ export const defaultRetries = 3;
 export const defaultPollInterval = 1000;
 
 /**
+ * Atomically claims the next ready task. Pops the tail of the ready list and, if
+ * the task data still exists, records it in the processing set with a
+ * server-derived deadline, increments the attempt counter, and bumps the
+ * per-task fence token. Orphaned ids (task data already deleted) have their
+ * counters cleaned up and are skipped.
+ *
+ * KEYS[1] ready list, KEYS[2] processing zset.
+ * ARGV[1] per-task key prefix (`<queue>:task:`), ARGV[2] default timeout (ms).
+ * Returns nil when nothing claimable, else [taskId, taskJson, attempt, fence].
+ *
+ * The per-task keys are built from ARGV[1] because the id is unknown until RPOP;
+ * this is safe on standalone/Sentinel Valkey/Redis but not on Cluster.
+ */
+const CLAIM_SCRIPT = `
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+for _ = 1, 100 do
+	local id = redis.call('RPOP', KEYS[1])
+	if not id then
+		return nil
+	end
+	local data = redis.call('GET', ARGV[1] .. id)
+	if data then
+		local timeout = tonumber(ARGV[2])
+		local ok, task = pcall(cjson.decode, data)
+		if ok and type(task) == 'table' and type(task.timeout) == 'number' then
+			timeout = task.timeout
+		end
+		redis.call('ZADD', KEYS[2], now + timeout, id)
+		local attempt = redis.call('INCR', ARGV[1] .. id .. ':attempt')
+		local fence = redis.call('INCR', ARGV[1] .. id .. ':fence')
+		return { id, data, attempt, tostring(fence) }
+	end
+	redis.call('DEL', ARGV[1] .. id .. ':attempt', ARGV[1] .. id .. ':fence')
+end
+return nil
+`;
+
+/**
+ * Acknowledges (completes) a task, but only if this delivery still owns it.
+ *
+ * KEYS[1] processing zset, KEYS[2] task data, KEYS[3] attempt, KEYS[4] fence.
+ * ARGV[1] fence token, ARGV[2] taskId. Returns 1 if removed, 0 if stale.
+ */
+const ACK_SCRIPT = `
+if redis.call('GET', KEYS[4]) ~= ARGV[1] then
+	return 0
+end
+redis.call('ZREM', KEYS[1], ARGV[2])
+redis.call('DEL', KEYS[2], KEYS[3], KEYS[4])
+return 1
+`;
+
+/**
+ * Rejects a task, requeueing it for retry or moving it to the dead-letter queue,
+ * but only if this delivery still owns it. The fence token is consumed either
+ * way so no other holder of the token can act on the task afterwards.
+ *
+ * KEYS[1] processing, KEYS[2] ready, KEYS[3] dead-letter, KEYS[4] attempt,
+ * KEYS[5] fence. ARGV[1] token, ARGV[2] taskId, ARGV[3] "1"|"0" requeue flag,
+ * ARGV[4] maxRetries. Returns 1 if applied, 0 if stale.
+ */
+const REJECT_SCRIPT = `
+if redis.call('GET', KEYS[5]) ~= ARGV[1] then
+	return 0
+end
+redis.call('ZREM', KEYS[1], ARGV[2])
+local attempt = tonumber(redis.call('GET', KEYS[4]) or '0')
+if ARGV[3] == '1' and attempt < tonumber(ARGV[4]) then
+	redis.call('INCR', KEYS[5])
+	redis.call('LPUSH', KEYS[2], ARGV[2])
+else
+	redis.call('DEL', KEYS[5])
+	redis.call('LPUSH', KEYS[3], ARGV[2])
+end
+return 1
+`;
+
+/**
+ * Extends a task's visibility deadline, but only if this delivery still owns it.
+ * Uses XX (not GT) so extend() may legally shorten the deadline.
+ *
+ * KEYS[1] processing zset, KEYS[2] fence.
+ * ARGV[1] token, ARGV[2] taskId, ARGV[3] ttl (ms). Returns 1 if updated, 0 stale.
+ */
+const EXTEND_SCRIPT = `
+if redis.call('GET', KEYS[2]) ~= ARGV[1] then
+	return 0
+end
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('ZADD', KEYS[1], 'XX', now + tonumber(ARGV[3]), ARGV[2])
+return 1
+`;
+
+/**
+ * Recovers a timed-out task: re-checks expiry against the server clock, and if
+ * still expired removes it from processing, invalidates the stale owner's fence
+ * token, and requeues it (retries remaining) or dead-letters it. Mutates nothing
+ * when the task is no longer expired (a fresh delivery re-claimed it) or gone.
+ *
+ * KEYS[1] processing, KEYS[2] ready, KEYS[3] dead-letter, KEYS[4] attempt,
+ * KEYS[5] fence. ARGV[1] taskId, ARGV[2] maxRetries. Returns 1 if recovered.
+ */
+const RECOVER_SCRIPT = `
+local score = redis.call('ZSCORE', KEYS[1], ARGV[1])
+if not score then
+	return 0
+end
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+if tonumber(score) >= now then
+	return 0
+end
+redis.call('ZREM', KEYS[1], ARGV[1])
+local attempt = tonumber(redis.call('GET', KEYS[4]) or '0')
+if attempt < tonumber(ARGV[2]) then
+	redis.call('INCR', KEYS[5])
+	redis.call('LPUSH', KEYS[2], ARGV[1])
+else
+	redis.call('DEL', KEYS[5])
+	redis.call('LPUSH', KEYS[3], ARGV[1])
+end
+return 1
+`;
+
+/**
  * Valkey-based task provider for Qified.
  * Uses Valkey lists and sorted sets to enable reliable task queue processing
  * across multiple instances with visibility timeout, retries, and dead-letter queues.
  * Extends Hookified to emit events for errors and other lifecycle events.
+ *
+ * Distributed semantics:
+ * - Delivery is at-least-once: a handler that finishes right at its visibility
+ *   deadline can race recovery and run more than once, so handlers must be
+ *   idempotent.
+ * - Claim, acknowledge, reject, extend, and timeout-recovery run as atomic Lua
+ *   scripts. Each delivery carries a monotonic per-task fence token; an operation
+ *   from a delivery that has lost ownership (its token no longer matches) is a
+ *   no-op, so a stale worker cannot corrupt a newer delivery.
+ * - When several handlers are registered on one queue they share a single
+ *   delivery and token; the first acknowledgement or rejection decides the
+ *   outcome ("first finalizer wins").
+ * - Standalone/Sentinel only: the claim script builds per-task keys from a prefix
+ *   and the key schema is not Redis Cluster compatible.
  */
 export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 	private _id: string;
@@ -54,7 +195,6 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 	private _active = true;
 	private _pollInterval: number;
 	private _pollTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
-	private _processingTasks: Map<string, Set<string>> = new Map();
 
 	/**
 	 * Creates a new Valkey task provider instance.
@@ -205,6 +345,22 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 	}
 
 	/**
+	 * Gets the Valkey key for the task fence token, used to detect stale
+	 * operations from a delivery that has lost ownership of the task.
+	 */
+	private getTaskFenceKey(queue: string, taskId: string): string {
+		return `${queue}:task:${taskId}:fence`;
+	}
+
+	/**
+	 * Gets the shared per-task key prefix (`<queue>:task:`) that the claim script
+	 * uses to build per-task keys from the popped task id.
+	 */
+	private getTaskKeyPrefix(queue: string): string {
+		return `${queue}:task:`;
+	}
+
+	/**
 	 * Enqueues a task to a specific queue.
 	 * @param queue The queue name to enqueue to
 	 * @param taskData The task data to enqueue
@@ -301,7 +457,9 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 		const client = await this.getClient();
 		const now = Date.now();
 
-		// Get tasks with deadline < now
+		// Advisory scan for tasks whose deadline has passed. RECOVER re-checks
+		// expiry against the server clock before acting, so a fast/slow local
+		// clock only affects recovery latency, never correctness.
 		const timedOutTasks = await client.zrangebyscore(
 			this.getProcessingKey(queue),
 			0,
@@ -313,41 +471,33 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 			if (!this._active) {
 				return;
 			}
-			// Get attempt count
-			const attemptStr = await client.get(
-				this.getTaskAttemptKey(queue, taskId),
-			);
-			const attempt = Number.parseInt(attemptStr ?? "0", 10);
 
-			// Get task data to check maxRetries
+			// Get task data to check maxRetries.
 			const taskDataStr = await client.get(this.getTaskDataKey(queue, taskId));
 			if (!taskDataStr) {
-				// Task data missing, clean up
+				// Task data missing; drop the orphaned processing entry and counters.
 				await client.zrem(this.getProcessingKey(queue), taskId);
+				await client.del(this.getTaskAttemptKey(queue, taskId));
+				await client.del(this.getTaskFenceKey(queue, taskId));
 				continue;
 			}
 
 			const task = JSON.parse(taskDataStr) as Task;
 			const maxRetries = task.maxRetries ?? this._retries;
 
-			// Remove from processing. If another instance already claimed this
-			// task, zrem returns 0 and we skip requeueing/dead-lettering it.
-			const removed = await client.zrem(this.getProcessingKey(queue), taskId);
-			/* v8 ignore next 3 -- @preserve */
-			if (removed === 0) {
-				continue;
-			}
-
-			// Remove from local processing set
-			this._processingTasks.get(queue)?.delete(taskId);
-
-			if (attempt < maxRetries) {
-				// Requeue for retry
-				await client.lpush(this.getQueueKey(queue), taskId);
-			} else {
-				// Move to dead-letter queue
-				await client.lpush(this.getDeadLetterKey(queue), taskId);
-			}
+			// Atomically recover the task: re-verify expiry, invalidate the stale
+			// owner's fence token, and requeue or dead-letter it.
+			await client.eval(
+				RECOVER_SCRIPT,
+				5,
+				this.getProcessingKey(queue),
+				this.getQueueKey(queue),
+				this.getDeadLetterKey(queue),
+				this.getTaskAttemptKey(queue, taskId),
+				this.getTaskFenceKey(queue, taskId),
+				taskId,
+				String(maxRetries),
+			);
 		}
 	}
 
@@ -372,51 +522,36 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 			return;
 		}
 
-		// Initialize processing set for this queue if needed
-		if (!this._processingTasks.has(queue)) {
-			this._processingTasks.set(queue, new Set());
-		}
-
-		/* v8 ignore next -- @preserve */
-		const processingSet = this._processingTasks.get(queue) ?? new Set<string>();
-
-		// Get task from queue
-		let taskId: string | null;
+		// Atomically claim the next task (RPOP ready + ZADD processing + bump
+		// attempt and fence) so a crash can never leave it in neither structure.
+		let reply: [string, string, number, string] | null;
 		try {
-			taskId = await client.rpop(this.getQueueKey(queue));
+			reply = (await client.eval(
+				CLAIM_SCRIPT,
+				2,
+				this.getQueueKey(queue),
+				this.getProcessingKey(queue),
+				this.getTaskKeyPrefix(queue),
+				String(this._timeout),
+			)) as [string, string, number, string] | null;
 		} catch (error) {
 			/* v8 ignore start -- @preserve */
 			this.emit("error", error);
 			return;
 			/* v8 ignore stop */
 		}
-		if (!taskId) {
+
+		if (!reply) {
 			return;
 		}
 
-		// Check if already being processed locally
-		/* v8 ignore next 4 -- @preserve */
-		if (processingSet.has(taskId)) {
-			// Put back in queue and return
-			await client.lpush(this.getQueueKey(queue), taskId);
-			return;
-		}
-
-		// Get task data
-		const taskDataStr = await client.get(this.getTaskDataKey(queue, taskId));
-		if (!taskDataStr) {
-			// Task data missing, skip
-			return;
-		}
-
+		const [, taskDataStr, attempt, token] = reply;
 		const task = JSON.parse(taskDataStr) as Task;
 
-		// Mark as processing locally
-		processingSet.add(taskId);
-
-		// Process with each handler
+		// Process with each handler. They share one delivery and fence token;
+		// the first ack/reject wins.
 		for (const handler of handlers) {
-			void this.processTask(queue, task, handler);
+			void this.processTask(queue, task, handler, attempt, token);
 		}
 
 		// Continue processing more tasks
@@ -430,17 +565,12 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 		queue: string,
 		task: Task,
 		handler: TaskHandler,
+		attempt: number,
+		token: string,
 	): Promise<void> {
 		const client = await this.getClient();
 		const maxRetries = task.maxRetries ?? this._retries;
 		const timeout = task.timeout ?? this._timeout;
-
-		// Increment attempt count
-		const attempt = await client.incr(this.getTaskAttemptKey(queue, task.id));
-
-		// Add to processing sorted set with deadline
-		const deadline = Date.now() + timeout;
-		await client.zadd(this.getProcessingKey(queue), deadline, task.id);
 
 		let acknowledged = false;
 		let rejected = false;
@@ -454,7 +584,7 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 				}
 				acknowledged = true;
 				try {
-					await this.removeTask(queue, task.id);
+					await this.removeTask(queue, task.id, token);
 				} catch (error) {
 					/* v8 ignore next -- @preserve */
 					this.emit("error", error);
@@ -467,17 +597,21 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 				rejected = true;
 
 				try {
-					// Remove from processing
-					await client.zrem(this.getProcessingKey(queue), task.id);
-					this._processingTasks.get(queue)?.delete(task.id);
-
-					if (requeue && attempt < maxRetries) {
-						// Requeue for retry
-						await client.lpush(this.getQueueKey(queue), task.id);
-					} else {
-						// Move to dead-letter queue
-						await client.lpush(this.getDeadLetterKey(queue), task.id);
-					}
+					// Remove from processing and requeue or dead-letter, but only
+					// if this delivery still owns the task (fence token matches).
+					await client.eval(
+						REJECT_SCRIPT,
+						5,
+						this.getProcessingKey(queue),
+						this.getQueueKey(queue),
+						this.getDeadLetterKey(queue),
+						this.getTaskAttemptKey(queue, task.id),
+						this.getTaskFenceKey(queue, task.id),
+						token,
+						task.id,
+						requeue ? "1" : "0",
+						String(maxRetries),
+					);
 				} catch (error) {
 					/* v8 ignore next -- @preserve */
 					this.emit("error", error);
@@ -488,15 +622,15 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 					return;
 				}
 				try {
-					// Update deadline in processing set. "XX" only updates the
-					// score if the task is still tracked, avoiding re-adding a
-					// task that already timed out and left the processing set.
-					const newDeadline = Date.now() + ttl;
-					await client.zadd(
+					// Extend the deadline only if this delivery still owns the task.
+					await client.eval(
+						EXTEND_SCRIPT,
+						2,
 						this.getProcessingKey(queue),
-						"XX",
-						newDeadline,
+						this.getTaskFenceKey(queue, task.id),
+						token,
 						task.id,
+						String(ttl),
 					);
 					// Reset timeout handle
 					/* v8 ignore start -- @preserve */
@@ -561,22 +695,26 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 	}
 
 	/**
-	 * Removes a task completely (on successful ack).
+	 * Removes a task completely (on successful ack), if this delivery still owns
+	 * it. A stale acknowledgement whose fence token no longer matches is a no-op.
 	 */
-	private async removeTask(queue: string, taskId: string): Promise<void> {
+	private async removeTask(
+		queue: string,
+		taskId: string,
+		token: string,
+	): Promise<void> {
 		const client = await this.getClient();
 
-		// Remove from processing set
-		await client.zrem(this.getProcessingKey(queue), taskId);
-
-		// Remove task data
-		await client.del(this.getTaskDataKey(queue, taskId));
-
-		// Remove attempt counter
-		await client.del(this.getTaskAttemptKey(queue, taskId));
-
-		// Remove from local processing set
-		this._processingTasks.get(queue)?.delete(taskId);
+		await client.eval(
+			ACK_SCRIPT,
+			4,
+			this.getProcessingKey(queue),
+			this.getTaskDataKey(queue, taskId),
+			this.getTaskAttemptKey(queue, taskId),
+			this.getTaskFenceKey(queue, taskId),
+			token,
+			taskId,
+		);
 	}
 
 	/**
@@ -625,7 +763,6 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 
 		// Clear handlers
 		this._taskHandlers.clear();
-		this._processingTasks.clear();
 
 		// Disconnect from Valkey
 		if (this._connectionPromise) {
@@ -707,10 +844,11 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 
 		const allTaskIds = [...queueTasks, ...processingTasks, ...deadLetterTasks];
 
-		// Delete all task data and attempt counters
+		// Delete all task data, attempt, and fence keys
 		for (const taskId of allTaskIds) {
 			await client.del(this.getTaskDataKey(queue, taskId));
 			await client.del(this.getTaskAttemptKey(queue, taskId));
+			await client.del(this.getTaskFenceKey(queue, taskId));
 		}
 
 		// Clear all queue structures

--- a/packages/valkey/src/task.ts
+++ b/packages/valkey/src/task.ts
@@ -330,8 +330,13 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 			const task = JSON.parse(taskDataStr) as Task;
 			const maxRetries = task.maxRetries ?? this._retries;
 
-			// Remove from processing
-			await client.zrem(this.getProcessingKey(queue), taskId);
+			// Remove from processing. If another instance already claimed this
+			// task, zrem returns 0 and we skip requeueing/dead-lettering it.
+			const removed = await client.zrem(this.getProcessingKey(queue), taskId);
+			/* v8 ignore next 3 -- @preserve */
+			if (removed === 0) {
+				continue;
+			}
 
 			// Remove from local processing set
 			this._processingTasks.get(queue)?.delete(taskId);
@@ -483,9 +488,16 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 					return;
 				}
 				try {
-					// Update deadline in processing set
+					// Update deadline in processing set. "XX" only updates the
+					// score if the task is still tracked, avoiding re-adding a
+					// task that already timed out and left the processing set.
 					const newDeadline = Date.now() + ttl;
-					await client.zadd(this.getProcessingKey(queue), newDeadline, task.id);
+					await client.zadd(
+						this.getProcessingKey(queue),
+						"XX",
+						newDeadline,
+						task.id,
+					);
 					// Reset timeout handle
 					/* v8 ignore start -- @preserve */
 					if (timeoutHandle) {

--- a/packages/valkey/src/task.ts
+++ b/packages/valkey/src/task.ts
@@ -513,6 +513,7 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 							}
 						}
 					}, ttl);
+					timeoutHandle.unref();
 				} catch (error) {
 					this.emit("error", error);
 				}
@@ -535,6 +536,8 @@ export class ValkeyTaskProvider extends Hookified implements TaskProvider {
 				}
 			}
 		}, timeout);
+		// Do not let a pending task timeout keep the process alive on its own.
+		timeoutHandle.unref();
 
 		try {
 			await handler.handler(task, context);

--- a/packages/valkey/test/index.test.ts
+++ b/packages/valkey/test/index.test.ts
@@ -1,0 +1,131 @@
+import { type Message, Qified } from "qified";
+import { describe, expect, test } from "vitest";
+import {
+	createQified,
+	defaultValkeyId,
+	ValkeyMessageProvider,
+} from "../src/index.js";
+
+describe("ValkeyMessageProvider", () => {
+	test("should fail to connect when Valkey is not available", async () => {
+		const provider = new ValkeyMessageProvider({
+			uri: "redis://localhost:9999",
+		}); // Use non-existent port
+		await expect(provider.connect()).rejects.toThrow();
+	});
+
+	test("should publish and receive a message", async () => {
+		const provider = new ValkeyMessageProvider();
+		const message: Omit<Message, "providerId"> = { id: "1", data: "test" };
+		let received: Message | undefined;
+		const id = "test-handler";
+		await provider.subscribe("test-topic", {
+			id,
+			async handler(message) {
+				received = message;
+			},
+		});
+		await provider.publish("test-topic", message);
+		// Wait a moment for async delivery
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+		expect(received).toEqual({ ...message, providerId: defaultValkeyId });
+
+		await provider.unsubscribe("test-topic", id);
+		await provider.disconnect();
+	});
+
+	test("should unsubscribe all handlers with no id", async () => {
+		const provider = new ValkeyMessageProvider();
+		const message: Omit<Message, "providerId"> = { id: "1", data: "test" };
+		let received1: Message | undefined;
+		let received2: Message | undefined;
+		await provider.subscribe("test-topic", {
+			async handler(message) {
+				received1 = message;
+			},
+		});
+
+		await provider.subscribe("test-topic", {
+			async handler(message) {
+				received2 = message;
+			},
+		});
+
+		await provider.publish("test-topic", message);
+
+		const firstSubscriptions = provider.subscriptions.get("test-topic");
+		expect(firstSubscriptions?.length).toBe(2);
+
+		// Wait a moment for async delivery
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+		expect(received1).toEqual({ ...message, providerId: defaultValkeyId });
+		expect(received2).toEqual({ ...message, providerId: defaultValkeyId });
+
+		await provider.unsubscribe("test-topic");
+
+		const subscriptions = provider.subscriptions.get("test-topic");
+		expect(subscriptions).toBeUndefined();
+
+		await provider.disconnect();
+	});
+
+	test("should be able to use with Qified", async () => {
+		const provider = new ValkeyMessageProvider();
+		const qified = new Qified({ messageProviders: [provider] });
+		const message: Omit<Message, "providerId"> = { id: "1", data: "test" };
+		let received: Message | undefined;
+		const id = "test-handler";
+		await qified.subscribe("test-topic", {
+			id,
+			async handler(message) {
+				received = message;
+			},
+		});
+		await qified.publish("test-topic", message);
+		// Wait a moment for async delivery
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+		expect(received).toEqual({ ...message, providerId: defaultValkeyId });
+
+		await qified.unsubscribeMessage("test-topic", id);
+		await qified.disconnect();
+	});
+
+	test("should create Qified instance with Valkey provider", () => {
+		const qified = createQified();
+		expect(qified).toBeInstanceOf(Qified);
+		expect(qified.messageProviders.length).toBe(1);
+		expect(qified.messageProviders[0]).toBeInstanceOf(ValkeyMessageProvider);
+	});
+
+	test("should get provider id", () => {
+		const provider = new ValkeyMessageProvider();
+		expect(provider.id).toBe(defaultValkeyId);
+	});
+
+	test("should set provider id", async () => {
+		const customId = "custom-valkey-id";
+		const provider = new ValkeyMessageProvider({ id: customId });
+		expect(provider.id).toBe(customId);
+
+		provider.id = "new-id";
+		expect(provider.id).toBe("new-id");
+	});
+
+	test("should force disconnect and destroy connections", async () => {
+		const provider = new ValkeyMessageProvider();
+		await provider.connect();
+		await provider.subscribe("test-topic", {
+			id: "test-handler",
+			async handler() {},
+		});
+		// Force disconnect should call disconnect() instead of quit()
+		await provider.disconnect(true);
+		expect(provider.subscriptions.size).toBe(0);
+	});
+});

--- a/packages/valkey/test/index.test.ts
+++ b/packages/valkey/test/index.test.ts
@@ -125,6 +125,33 @@ describe("ValkeyMessageProvider", () => {
 		await provider.disconnect();
 	});
 
+	test("should roll back topic state when subscribe fails", async () => {
+		const provider = new ValkeyMessageProvider({
+			uri: "redis://localhost:9999",
+		});
+		await expect(
+			provider.subscribe("test-topic", { async handler() {} }),
+		).rejects.toThrow();
+		// The topic entry must not linger, or a later retry would skip the real
+		// subscribe and never receive messages.
+		expect(provider.subscriptions.has("test-topic")).toBe(false);
+	});
+
+	test("should not crash when a handler rejects", async () => {
+		const provider = new ValkeyMessageProvider();
+		await provider.subscribe("test-topic", {
+			async handler() {
+				throw new Error("handler failure");
+			},
+		});
+		await provider.publish("test-topic", { id: "1", data: "test" });
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+		await provider.disconnect();
+		expect(provider.subscriptions.size).toBe(0);
+	});
+
 	test("should get provider id", () => {
 		const provider = new ValkeyMessageProvider();
 		expect(provider.id).toBe(defaultValkeyId);

--- a/packages/valkey/test/index.test.ts
+++ b/packages/valkey/test/index.test.ts
@@ -103,6 +103,28 @@ describe("ValkeyMessageProvider", () => {
 		expect(qified.messageProviders[0]).toBeInstanceOf(ValkeyMessageProvider);
 	});
 
+	test("should ignore malformed messages without crashing", async () => {
+		const provider = new ValkeyMessageProvider();
+		let received: Message | undefined;
+		await provider.subscribe("test-topic", {
+			async handler(message) {
+				received = message;
+			},
+		});
+		// Publish a raw, non-JSON payload directly on the channel to exercise the
+		// parse-error path in the subscriber's message listener.
+		const { pub } = provider as unknown as {
+			pub: { publish(channel: string, message: string): Promise<number> };
+		};
+		await pub.publish("test-topic", "not-json{");
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+		expect(received).toBeUndefined();
+
+		await provider.disconnect();
+	});
+
 	test("should get provider id", () => {
 		const provider = new ValkeyMessageProvider();
 		expect(provider.id).toBe(defaultValkeyId);

--- a/packages/valkey/test/task.test.ts
+++ b/packages/valkey/test/task.test.ts
@@ -1506,4 +1506,250 @@ describe("ValkeyTaskProvider", () => {
 			await customProvider.disconnect();
 		});
 	});
+
+	describe("fencing and distributed safety", () => {
+		test("should ignore a stale ack after the fence token changes", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task, ctx: TaskContext) => {
+					// Simulate another worker re-claiming the task by bumping the
+					// fence, making this delivery's token stale, then ack.
+					await client.incr(`${testQueue}:task:${task.id}:fence`);
+					await ctx.ack();
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			const taskId = await customProvider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// The stale ack must not delete the task or drop the processing entry.
+			expect(await client.get(`${testQueue}:task:${taskId}`)).not.toBeNull();
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats.processing).toBe(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should ignore a stale reject after the fence token changes", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task, ctx: TaskContext) => {
+					await client.incr(`${testQueue}:task:${task.id}:fence`);
+					await ctx.reject(false);
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			const taskId = await customProvider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// The stale reject must not move the task to the dead-letter queue.
+			const dlq = await customProvider.getDeadLetterTasks(testQueue);
+			expect(dlq.length).toBe(0);
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats.processing).toBe(1);
+			expect(await client.get(`${testQueue}:task:${taskId}`)).not.toBeNull();
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should ignore a stale extend after the fence token changes", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			let completed = false;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task, ctx: TaskContext) => {
+					const before = await client.zscore(
+						`${testQueue}:processing`,
+						task.id,
+					);
+					await client.incr(`${testQueue}:task:${task.id}:fence`);
+					await ctx.extend(120000);
+					const after = await client.zscore(`${testQueue}:processing`, task.id);
+					// A stale extend must not move the deadline.
+					expect(after).toBe(before);
+					completed = true;
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+			expect(completed).toBe(true);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should let the first finalizer win across multiple handlers", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 60000,
+				pollInterval: 60000,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const handlerA: TaskHandler = {
+				id: "handler-a",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.ack();
+				},
+			};
+			const handlerB: TaskHandler = {
+				id: "handler-b",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					// Finish after A has already finalized; this reject is fenced out.
+					await new Promise((resolve) => setTimeout(resolve, 80));
+					await ctx.reject(false);
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handlerA);
+			await customProvider.dequeue(testQueue, handlerB);
+			const taskId = await customProvider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 250));
+
+			const dlq = await customProvider.getDeadLetterTasks(testQueue);
+			expect(dlq.length).toBe(0);
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats).toEqual({ waiting: 0, processing: 0, deadLetter: 0 });
+			expect(await client.exists(`${testQueue}:task:${taskId}`)).toBe(0);
+			expect(await client.exists(`${testQueue}:task:${taskId}:fence`)).toBe(0);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should recover a timed-out task and invalidate the stale owner", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				pollInterval: 25,
+				retries: 3,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const taskId = "recover-task";
+			await client.set(
+				`${testQueue}:task:${taskId}`,
+				JSON.stringify({ id: taskId, data: { message: "test" } }),
+			);
+			await client.set(`${testQueue}:task:${taskId}:attempt`, "0");
+			await client.set(`${testQueue}:task:${taskId}:fence`, "1");
+			// Already-expired processing entry owned by a now-dead worker.
+			await client.zadd(`${testQueue}:processing`, Date.now() - 1000, taskId);
+
+			let seenAttempt: number | undefined;
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					seenAttempt = ctx.metadata.attempt;
+					await ctx.ack();
+				},
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			// RECOVER requeued it (attempt 0 < 3); CLAIM re-delivered as attempt 1.
+			expect(seenAttempt).toBe(1);
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats).toEqual({ waiting: 0, processing: 0, deadLetter: 0 });
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should clean up counters for orphaned task ids on claim", async () => {
+			const customProvider = new ValkeyTaskProvider({ pollInterval: 60000 });
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			// A ready id whose task data was deleted, with leftover counters.
+			await client.set(`${testQueue}:task:orphan-task-id:attempt`, "5");
+			await client.set(`${testQueue}:task:orphan-task-id:fence`, "7");
+			await client.lpush(`${testQueue}:tasks`, "orphan-task-id");
+
+			let handlerCalled = false;
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {
+					handlerCalled = true;
+				},
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			expect(handlerCalled).toBe(false);
+			expect(
+				await client.exists(`${testQueue}:task:orphan-task-id:attempt`),
+			).toBe(0);
+			expect(
+				await client.exists(`${testQueue}:task:orphan-task-id:fence`),
+			).toBe(0);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should remove fence keys on clearQueue", async () => {
+			const customProvider = new ValkeyTaskProvider();
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const client = (customProvider as any)._client;
+			const taskId = "fence-task";
+			await client.set(
+				`${testQueue}:task:${taskId}`,
+				JSON.stringify({ id: taskId, data: {} }),
+			);
+			await client.set(`${testQueue}:task:${taskId}:attempt`, "1");
+			await client.set(`${testQueue}:task:${taskId}:fence`, "1");
+			await client.zadd(`${testQueue}:processing`, Date.now() + 60000, taskId);
+
+			expect(await client.exists(`${testQueue}:task:${taskId}:fence`)).toBe(1);
+			await customProvider.clearQueue(testQueue);
+			expect(await client.exists(`${testQueue}:task:${taskId}:fence`)).toBe(0);
+
+			await customProvider.disconnect();
+		});
+	});
 });

--- a/packages/valkey/test/task.test.ts
+++ b/packages/valkey/test/task.test.ts
@@ -1,0 +1,1509 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: This is a test file and explicit any is acceptable here.
+
+import type { Task, TaskContext, TaskHandler } from "qified";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	defaultTaskRetries,
+	defaultTaskTimeout,
+	defaultValkeyTaskId,
+	ValkeyTaskProvider,
+} from "../src/index.js";
+
+describe("ValkeyTaskProvider", () => {
+	let provider: ValkeyTaskProvider;
+	const testQueue = `test-queue-${Date.now()}`;
+
+	describe("hookified inheritance", () => {
+		test("should extend Hookified and support event emission", () => {
+			const p = new ValkeyTaskProvider();
+			expect(typeof p.on).toBe("function");
+			expect(typeof p.emit).toBe("function");
+			expect(typeof p.off).toBe("function");
+		});
+
+		test("should emit error events when Valkey operations fail in ack", async () => {
+			const customProvider = new ValkeyTaskProvider();
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const errors: Error[] = [];
+			customProvider.on("error", (error: Error) => {
+				errors.push(error);
+			});
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, _ctx: TaskContext) => {
+					// Handler completes, auto-ack will happen
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for task to be processed
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// Clean up
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+
+			// Create a new provider to verify error listener support
+			const p2 = new ValkeyTaskProvider();
+			await p2.connect();
+			await p2.clearQueue(testQueue);
+
+			const errors2: Error[] = [];
+			p2.on("error", (error: Error) => {
+				errors2.push(error);
+			});
+
+			// The error emission is verified by the existence of the listener
+			expect(typeof p2.on).toBe("function");
+
+			await p2.clearQueue(testQueue);
+			await p2.disconnect();
+		});
+
+		test("should emit error events during polling when Valkey fails", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				pollInterval: 50,
+				uri: "redis://localhost:6380",
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const errors: Error[] = [];
+			customProvider.on("error", (error: Error) => {
+				errors.push(error);
+			});
+
+			// Register a handler to start polling
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {},
+			});
+
+			// Wait for polling to run
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// Clean up - no errors should have occurred in normal operation
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+
+			// Verify error listener was registered (proves hookified works)
+			expect(typeof customProvider.on).toBe("function");
+		});
+
+		test("should support onHook and removeHook from Hookified", () => {
+			const p = new ValkeyTaskProvider();
+			expect(typeof p.onHook).toBe("function");
+			expect(typeof p.removeHook).toBe("function");
+		});
+
+		test("should support once method from Hookified", () => {
+			const p = new ValkeyTaskProvider();
+			expect(typeof p.once).toBe("function");
+		});
+	});
+
+	beforeEach(async () => {
+		provider = new ValkeyTaskProvider();
+		provider.throwOnEmptyListeners = false;
+		await provider.connect();
+		await provider.clearQueue(testQueue);
+	});
+
+	afterEach(async () => {
+		await provider.clearQueue(testQueue);
+		await provider.disconnect();
+	});
+
+	describe("constructor and initialization", () => {
+		test("should initialize with default values", () => {
+			const p = new ValkeyTaskProvider();
+			expect(p.id).toBe(defaultValkeyTaskId);
+			expect(p.timeout).toBe(defaultTaskTimeout);
+			expect(p.retries).toBe(defaultTaskRetries);
+			expect(p.taskHandlers).toEqual(new Map());
+		});
+
+		test("should initialize with custom id", () => {
+			const customProvider = new ValkeyTaskProvider({ id: "custom-id" });
+			expect(customProvider.id).toBe("custom-id");
+		});
+
+		test("should initialize with custom timeout", () => {
+			const customProvider = new ValkeyTaskProvider({ timeout: 5000 });
+			expect(customProvider.timeout).toBe(5000);
+		});
+
+		test("should initialize with custom retries", () => {
+			const customProvider = new ValkeyTaskProvider({ retries: 5 });
+			expect(customProvider.retries).toBe(5);
+		});
+
+		test("should initialize with all custom options", () => {
+			const customProvider = new ValkeyTaskProvider({
+				id: "custom-id",
+				timeout: 5000,
+				retries: 5,
+				pollInterval: 500,
+			});
+			expect(customProvider.id).toBe("custom-id");
+			expect(customProvider.timeout).toBe(5000);
+			expect(customProvider.retries).toBe(5);
+		});
+
+		test("should fail to connect when Valkey is not available", async () => {
+			const p = new ValkeyTaskProvider({ uri: "redis://localhost:9999" });
+			await expect(p.connect()).rejects.toThrow();
+		});
+	});
+
+	describe("getters and setters", () => {
+		test("should set and get id", () => {
+			provider.id = "new-id";
+			expect(provider.id).toBe("new-id");
+		});
+
+		test("should set and get timeout", () => {
+			provider.timeout = 10000;
+			expect(provider.timeout).toBe(10000);
+		});
+
+		test("should set and get retries", () => {
+			provider.retries = 10;
+			expect(provider.retries).toBe(10);
+		});
+
+		test("should set and get taskHandlers", () => {
+			const handlers = new Map<string, TaskHandler[]>();
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {},
+			};
+			handlers.set("test-queue", [handler]);
+			provider.taskHandlers = handlers;
+			expect(provider.taskHandlers).toBe(handlers);
+		});
+	});
+
+	describe("enqueue", () => {
+		test("should enqueue a task with auto-generated id and timestamp", async () => {
+			const taskId = await provider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			expect(taskId).toBeDefined();
+			expect(typeof taskId).toBe("string");
+			// UUID format: task-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			expect(taskId).toMatch(
+				/^task-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+			);
+		});
+
+		test("should enqueue multiple tasks with unique ids", async () => {
+			const taskId1 = await provider.enqueue(testQueue, {
+				data: { message: "test1" },
+			});
+			const taskId2 = await provider.enqueue(testQueue, {
+				data: { message: "test2" },
+			});
+
+			expect(taskId1).not.toBe(taskId2);
+		});
+
+		test("should enqueue task with all optional fields", async () => {
+			const taskId = await provider.enqueue(testQueue, {
+				data: { message: "test" },
+				headers: { "x-custom": "value" },
+				maxRetries: 5,
+				timeout: 5000,
+			});
+
+			expect(taskId).toBeDefined();
+		});
+
+		test("should throw error when disconnected", async () => {
+			await provider.disconnect();
+
+			await expect(
+				provider.enqueue(testQueue, { data: { message: "test" } }),
+			).rejects.toThrow("TaskProvider has been disconnected");
+		});
+	});
+
+	describe("dequeue and task processing", () => {
+		test("should register a handler for a queue", async () => {
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {},
+			};
+
+			await provider.dequeue(testQueue, handler);
+
+			expect(provider.taskHandlers.has(testQueue)).toBe(true);
+			expect(provider.taskHandlers.get(testQueue)?.length).toBe(1);
+			expect(provider.taskHandlers.get(testQueue)?.[0]).toBe(handler);
+		});
+
+		test("should register multiple handlers for the same queue", async () => {
+			const handler1: TaskHandler = {
+				id: "handler-1",
+				handler: async () => {},
+			};
+			const handler2: TaskHandler = {
+				id: "handler-2",
+				handler: async () => {},
+			};
+
+			await provider.dequeue(testQueue, handler1);
+			await provider.dequeue(testQueue, handler2);
+
+			expect(provider.taskHandlers.get(testQueue)?.length).toBe(2);
+		});
+
+		test("should process enqueued task when handler is registered", async () => {
+			let processedTask: Task | undefined;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task) => {
+					processedTask = task;
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			const taskId = await provider.enqueue(testQueue, {
+				data: { message: "test" },
+			});
+
+			// Wait a bit for async processing
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(processedTask).toBeDefined();
+			expect(processedTask?.id).toBe(taskId);
+			expect(processedTask?.data).toEqual({ message: "test" });
+		});
+
+		test("should auto-acknowledge task when handler completes successfully", async () => {
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					// Handler completes without error
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for processing
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			const stats = await provider.getQueueStats(testQueue);
+			expect(stats.waiting).toBe(0);
+			expect(stats.processing).toBe(0);
+		});
+
+		test("should throw error when disconnected", async () => {
+			await provider.disconnect();
+
+			await expect(
+				provider.dequeue(testQueue, { handler: async () => {} }),
+			).rejects.toThrow("TaskProvider has been disconnected");
+		});
+	});
+
+	describe("task acknowledgment", () => {
+		test("should acknowledge task explicitly", async () => {
+			let context: TaskContext | undefined;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					context = ctx;
+					await ctx.ack();
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(context).toBeDefined();
+			const stats = await provider.getQueueStats(testQueue);
+			expect(stats.waiting).toBe(0);
+			expect(stats.processing).toBe(0);
+		});
+
+		test("should not acknowledge twice", async () => {
+			let ackCount = 0;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.ack();
+					ackCount++;
+					await ctx.ack(); // Second ack should be no-op
+					ackCount++;
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(ackCount).toBe(2);
+			const stats = await provider.getQueueStats(testQueue);
+			expect(stats.waiting).toBe(0);
+		});
+	});
+
+	describe("task rejection and retry", () => {
+		test("should reject and requeue task on failure", async () => {
+			const customProvider = new ValkeyTaskProvider({ pollInterval: 100 });
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let attemptCount = 0;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					attemptCount++;
+					if (attemptCount === 1) {
+						await ctx.reject(true); // Requeue
+					} else {
+						await ctx.ack();
+					}
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for retry processing
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(attemptCount).toBeGreaterThan(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should move to dead-letter queue after max retries", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				retries: 2,
+				pollInterval: 100,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let attemptCount = 0;
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					attemptCount++;
+					await ctx.reject(true); // Always reject
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for all retries
+			await new Promise((resolve) => setTimeout(resolve, 800));
+
+			const deadLetterTasks =
+				await customProvider.getDeadLetterTasks(testQueue);
+			expect(deadLetterTasks.length).toBe(1);
+			expect(deadLetterTasks[0].data).toEqual({ message: "test" });
+			expect(attemptCount).toBe(2);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should move to dead-letter queue when reject with requeue=false", async () => {
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.reject(false); // Don't requeue
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			const deadLetterTasks = await provider.getDeadLetterTasks(testQueue);
+			expect(deadLetterTasks.length).toBe(1);
+		});
+
+		test("should not reject twice", async () => {
+			let rejectCount = 0;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.reject(false);
+					rejectCount++;
+					await ctx.reject(false); // Second reject should be no-op
+					rejectCount++;
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(rejectCount).toBe(2);
+			const deadLetterTasks = await provider.getDeadLetterTasks(testQueue);
+			expect(deadLetterTasks.length).toBe(1);
+		});
+
+		test("should auto-reject task on handler error", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				retries: 3,
+				pollInterval: 100,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let attemptCount = 0;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					attemptCount++;
+					throw new Error("Handler error");
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for retries
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+
+			expect(attemptCount).toBe(3);
+			const deadLetterTasks =
+				await customProvider.getDeadLetterTasks(testQueue);
+			expect(deadLetterTasks.length).toBe(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+	});
+
+	describe("task timeout", () => {
+		test("should timeout task after configured timeout", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 100,
+				pollInterval: 50,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let taskTimedOut = false;
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					// Simulate long-running task
+					await new Promise((resolve) => setTimeout(resolve, 300));
+					taskTimedOut = false; // Should not reach here
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			// Task should have timed out and be requeued
+			const stats = await customProvider.getQueueStats(testQueue);
+			// After timeout, task gets rejected and requeued
+			taskTimedOut =
+				stats.waiting > 0 || stats.deadLetter > 0 || stats.processing > 0;
+			expect(taskTimedOut).toBe(true);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+	});
+
+	describe("task context extend", () => {
+		test("should extend task deadline", async () => {
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 200,
+				pollInterval: 50,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let completed = false;
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					// Extend timeout before long operation
+					await ctx.extend(1000);
+					await new Promise((resolve) => setTimeout(resolve, 300));
+					completed = true;
+					await ctx.ack();
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			expect(completed).toBe(true);
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats.waiting).toBe(0);
+			expect(stats.processing).toBe(0);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should not extend after acknowledgment", async () => {
+			let extendCalled = false;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.ack();
+					await ctx.extend(1000); // Should be no-op
+					extendCalled = true;
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(extendCalled).toBe(true);
+		});
+	});
+
+	describe("task context metadata", () => {
+		test("should provide attempt and maxRetries in context", async () => {
+			let contextMetadata: any;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					contextMetadata = ctx.metadata;
+					await ctx.ack();
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(contextMetadata).toBeDefined();
+			expect(contextMetadata.attempt).toBe(1);
+			expect(contextMetadata.maxRetries).toBe(defaultTaskRetries);
+		});
+
+		test("should use task-specific maxRetries", async () => {
+			let contextMetadata: any;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					contextMetadata = ctx.metadata;
+					await ctx.ack();
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, {
+				data: { message: "test" },
+				maxRetries: 10,
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(contextMetadata.maxRetries).toBe(10);
+		});
+	});
+
+	describe("unsubscribe", () => {
+		test("should unsubscribe specific handler by id", async () => {
+			const handler1: TaskHandler = {
+				id: "handler-1",
+				handler: async () => {},
+			};
+			const handler2: TaskHandler = {
+				id: "handler-2",
+				handler: async () => {},
+			};
+
+			await provider.dequeue(testQueue, handler1);
+			await provider.dequeue(testQueue, handler2);
+
+			expect(provider.taskHandlers.get(testQueue)?.length).toBe(2);
+
+			await provider.unsubscribe(testQueue, "handler-1");
+
+			const handlers = provider.taskHandlers.get(testQueue);
+			expect(handlers?.length).toBe(1);
+			expect(handlers?.[0].id).toBe("handler-2");
+		});
+
+		test("should unsubscribe all handlers when id not provided", async () => {
+			const handler1: TaskHandler = {
+				id: "handler-1",
+				handler: async () => {},
+			};
+			const handler2: TaskHandler = {
+				id: "handler-2",
+				handler: async () => {},
+			};
+
+			await provider.dequeue(testQueue, handler1);
+			await provider.dequeue(testQueue, handler2);
+
+			expect(provider.taskHandlers.get(testQueue)?.length).toBe(2);
+
+			await provider.unsubscribe(testQueue);
+
+			expect(provider.taskHandlers.has(testQueue)).toBe(false);
+		});
+
+		test("should handle unsubscribe for non-existent queue", async () => {
+			await expect(
+				provider.unsubscribe("non-existent-queue", "handler-1"),
+			).resolves.not.toThrow();
+		});
+
+		test("should handle unsubscribe for non-existent handler id", async () => {
+			const handler: TaskHandler = {
+				id: "handler-1",
+				handler: async () => {},
+			};
+
+			await provider.dequeue(testQueue, handler);
+
+			await expect(
+				provider.unsubscribe(testQueue, "non-existent-handler"),
+			).resolves.not.toThrow();
+
+			expect(provider.taskHandlers.get(testQueue)?.length).toBe(1);
+		});
+	});
+
+	describe("disconnect", () => {
+		test("should clear all handlers on disconnect", async () => {
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			expect(provider.taskHandlers.size).toBeGreaterThan(0);
+
+			await provider.disconnect();
+
+			expect(provider.taskHandlers.size).toBe(0);
+		});
+
+		test("should prevent operations after disconnect", async () => {
+			await provider.disconnect();
+
+			await expect(
+				provider.enqueue(testQueue, { data: { message: "test" } }),
+			).rejects.toThrow("TaskProvider has been disconnected");
+
+			await expect(
+				provider.dequeue(testQueue, { handler: async () => {} }),
+			).rejects.toThrow("TaskProvider has been disconnected");
+		});
+
+		test("should force disconnect and destroy connections", async () => {
+			const p = new ValkeyTaskProvider();
+			await p.connect();
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {},
+			};
+			await p.dequeue(testQueue, handler);
+
+			// Force disconnect should call disconnect() instead of quit()
+			await p.disconnect(true);
+			expect(p.taskHandlers.size).toBe(0);
+		});
+	});
+
+	describe("getDeadLetterTasks", () => {
+		test("should return empty array for queue with no dead-letter tasks", async () => {
+			const deadLetterTasks = await provider.getDeadLetterTasks(testQueue);
+			expect(deadLetterTasks).toEqual([]);
+		});
+
+		test("should return dead-letter tasks for queue", async () => {
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.reject(false);
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test1" } });
+			await provider.enqueue(testQueue, { data: { message: "test2" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			const deadLetterTasks = await provider.getDeadLetterTasks(testQueue);
+			expect(deadLetterTasks.length).toBe(2);
+		});
+	});
+
+	describe("getQueueStats", () => {
+		test("should return empty stats for non-existent queue", async () => {
+			const stats = await provider.getQueueStats("non-existent-queue");
+			expect(stats).toEqual({
+				waiting: 0,
+				processing: 0,
+				deadLetter: 0,
+			});
+		});
+
+		test("should return correct stats for queue with waiting tasks", async () => {
+			await provider.enqueue(testQueue, { data: { message: "test1" } });
+			await provider.enqueue(testQueue, { data: { message: "test2" } });
+
+			const stats = await provider.getQueueStats(testQueue);
+			expect(stats.waiting).toBe(2);
+			expect(stats.processing).toBe(0);
+			expect(stats.deadLetter).toBe(0);
+		});
+
+		test("should return correct stats with dead-letter tasks", async () => {
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.reject(false);
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test1" } });
+			await provider.enqueue(testQueue, { data: { message: "test2" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			const stats = await provider.getQueueStats(testQueue);
+			expect(stats.waiting).toBe(0);
+			expect(stats.deadLetter).toBe(2);
+		});
+	});
+
+	describe("multiple handlers", () => {
+		test("should deliver task to all registered handlers", async () => {
+			let handler1Called = false;
+			let handler2Called = false;
+
+			const handler1: TaskHandler = {
+				id: "handler-1",
+				handler: async () => {
+					handler1Called = true;
+				},
+			};
+
+			const handler2: TaskHandler = {
+				id: "handler-2",
+				handler: async () => {
+					handler2Called = true;
+				},
+			};
+
+			await provider.dequeue(testQueue, handler1);
+			await provider.dequeue(testQueue, handler2);
+			await provider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(handler1Called).toBe(true);
+			expect(handler2Called).toBe(true);
+		});
+	});
+
+	describe("multiple queues", () => {
+		test("should maintain separate queues", async () => {
+			const queue1 = `${testQueue}-1`;
+			const queue2 = `${testQueue}-2`;
+
+			let queue1Processed = false;
+			let queue2Processed = false;
+
+			const handler1: TaskHandler = {
+				id: "handler-1",
+				handler: async () => {
+					queue1Processed = true;
+				},
+			};
+
+			const handler2: TaskHandler = {
+				id: "handler-2",
+				handler: async () => {
+					queue2Processed = true;
+				},
+			};
+
+			await provider.dequeue(queue1, handler1);
+			await provider.dequeue(queue2, handler2);
+			await provider.enqueue(queue1, { data: { message: "test1" } });
+			await provider.enqueue(queue2, { data: { message: "test2" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(queue1Processed).toBe(true);
+			expect(queue2Processed).toBe(true);
+
+			const stats1 = await provider.getQueueStats(queue1);
+			const stats2 = await provider.getQueueStats(queue2);
+
+			expect(stats1.waiting).toBe(0);
+			expect(stats2.waiting).toBe(0);
+
+			// Clean up
+			await provider.clearQueue(queue1);
+			await provider.clearQueue(queue2);
+		});
+	});
+
+	describe("task fields", () => {
+		test("should preserve task data fields", async () => {
+			let receivedTask: Task | undefined;
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (task: Task) => {
+					receivedTask = task;
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, {
+				data: { message: "test", nested: { value: 123 } },
+				headers: { "x-custom": "header-value" },
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(receivedTask).toBeDefined();
+			expect(receivedTask?.data).toEqual({
+				message: "test",
+				nested: { value: 123 },
+			});
+			expect(receivedTask?.headers).toEqual({ "x-custom": "header-value" });
+			expect(receivedTask?.timestamp).toBeDefined();
+		});
+	});
+
+	describe("clearQueue", () => {
+		test("should clear all data for a queue", async () => {
+			// Add tasks to various states
+			await provider.enqueue(testQueue, { data: { message: "test1" } });
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.reject(false);
+				},
+			};
+
+			await provider.dequeue(testQueue, handler);
+			await provider.enqueue(testQueue, { data: { message: "test3" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			// Verify data exists
+			const statsBefore = await provider.getQueueStats(testQueue);
+			expect(statsBefore.waiting + statsBefore.deadLetter).toBeGreaterThan(0);
+
+			// Clear queue
+			await provider.clearQueue(testQueue);
+
+			// Verify data is cleared
+			const statsAfter = await provider.getQueueStats(testQueue);
+			expect(statsAfter.waiting).toBe(0);
+			expect(statsAfter.processing).toBe(0);
+			expect(statsAfter.deadLetter).toBe(0);
+		});
+	});
+
+	describe("edge cases and coverage", () => {
+		test("should handle timed out tasks via background polling", async () => {
+			// This test covers checkTimedOutTasks (lines 335-366)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 50,
+				retries: 2,
+				pollInterval: 30,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					// Simulate long task that will timeout
+					await new Promise((resolve) => setTimeout(resolve, 200));
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for timeout detection via polling and retries
+			await new Promise((resolve) => setTimeout(resolve, 600));
+
+			// Task should have been retried and eventually moved to DLQ
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(
+				stats.deadLetter + stats.waiting + stats.processing,
+			).toBeGreaterThanOrEqual(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should handle disconnect during timed out task processing", async () => {
+			// This test covers early return in checkTimedOutTasks (lines 321, 335)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 20,
+				pollInterval: 30,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					// Long task that will timeout
+					await new Promise((resolve) => setTimeout(resolve, 500));
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+
+			// Enqueue multiple tasks
+			for (let i = 0; i < 3; i++) {
+				await customProvider.enqueue(testQueue, {
+					data: { message: `task-${i}` },
+				});
+			}
+
+			// Wait for tasks to start processing and timeout
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			// Disconnect while timeout handling is in progress
+			await customProvider.disconnect();
+
+			// Should not throw
+			expect(customProvider.taskHandlers.size).toBe(0);
+		});
+
+		test("should handle polling loop exit when inactive", async () => {
+			// This test covers line 269 (early return in poll when _active is false)
+			const customProvider = new ValkeyTaskProvider({ pollInterval: 20 });
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {},
+			});
+
+			// Let polling start
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			// Disconnect - this sets _active to false
+			await customProvider.disconnect();
+
+			// Wait a bit more - polling should have stopped
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// No errors should occur
+			expect(customProvider.taskHandlers.size).toBe(0);
+		});
+
+		test("should handle task data missing during processing", async () => {
+			// This test covers line 421 (task data missing, skip)
+			const customProvider = new ValkeyTaskProvider({ pollInterval: 50 });
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			// Manually add a task ID to the queue without task data
+			const client = (customProvider as any)._client;
+			await client.lpush(`${testQueue}:tasks`, "orphan-task-id");
+
+			let handlerCalled = false;
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {
+					handlerCalled = true;
+				},
+			});
+
+			// Wait for processing attempt
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// Handler should not have been called for orphan task
+			// But it shouldn't crash either
+			expect(handlerCalled).toBe(false);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should handle extended timeout expiration triggering reject", async () => {
+			// This test covers lines 515-516 (extended timeout firing)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 5000,
+				pollInterval: 50,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let extendCalled = false;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					// Extend with a short timeout
+					await ctx.extend(50);
+					extendCalled = true;
+					// Wait longer than the extended timeout
+					await new Promise((resolve) => setTimeout(resolve, 150));
+					// Task should have been auto-rejected by now via the extended timeout
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for processing and extended timeout to fire
+			await new Promise((resolve) => setTimeout(resolve, 300));
+
+			expect(extendCalled).toBe(true);
+
+			// The task should have been rejected (requeued or in DLQ)
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(
+				stats.waiting + stats.deadLetter + stats.processing,
+			).toBeGreaterThanOrEqual(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should handle processQueue when _active becomes false after getClient", async () => {
+			// This test covers line 376 (early return after getClient when _active is false)
+			const customProvider = new ValkeyTaskProvider({ pollInterval: 30 });
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					// Long operation
+					await new Promise((resolve) => setTimeout(resolve, 200));
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait just enough for processing to potentially start
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			// Disconnect while potentially in the middle of processQueue
+			await customProvider.disconnect();
+
+			// Should handle gracefully
+			expect(customProvider.taskHandlers.size).toBe(0);
+		});
+
+		test("should move timed out task to DLQ when max retries exceeded", async () => {
+			// This test specifically covers lines 364-366 (move to DLQ in checkTimedOutTasks)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 30,
+				retries: 1,
+				pollInterval: 20,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					// Always timeout by taking too long
+					await new Promise((resolve) => setTimeout(resolve, 200));
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for timeout detection, retry, and eventual DLQ
+			await new Promise((resolve) => setTimeout(resolve, 400));
+
+			// Task should eventually end up in dead letter queue
+			const stats = await customProvider.getQueueStats(testQueue);
+			// Either it's in DLQ, still processing, or waiting for retry
+			expect(
+				stats.deadLetter + stats.processing + stats.waiting,
+			).toBeGreaterThanOrEqual(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should handle missing task data in checkTimedOutTasks", async () => {
+			// This test covers lines 346-349 (task data missing cleanup in checkTimedOutTasks)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 30,
+				pollInterval: 20,
+			});
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			// Manually add a task ID to processing set without task data
+			const client = (customProvider as any)._client;
+			const processingKey = `${testQueue}:processing`;
+			await client.zadd(
+				processingKey,
+				Date.now() - 100,
+				"orphan-processing-task",
+			);
+
+			// Register handler to start polling
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {},
+			});
+
+			// Wait for checkTimedOutTasks to run and clean up orphan
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// The orphan task should have been cleaned up from processing set
+			const processingCount = await client.zcard(processingKey);
+			expect(processingCount).toBe(0);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should requeue timed out task when retries remaining via polling", async () => {
+			// This test covers lines 361-363 (requeue for retry in checkTimedOutTasks)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 30,
+				retries: 5,
+				pollInterval: 20,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let attemptCount = 0;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					attemptCount++;
+					if (attemptCount < 3) {
+						// First two attempts: let it timeout
+						await new Promise((resolve) => setTimeout(resolve, 200));
+					} else {
+						// Third attempt: complete successfully
+						await ctx.ack();
+					}
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			// Wait for timeouts and retries via polling
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			// Task should have been processed successfully after retries
+			expect(attemptCount).toBeGreaterThanOrEqual(1);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should move timed out task to DLQ via checkTimedOutTasks when retries exhausted", async () => {
+			// This test specifically targets line 366 (DLQ move in checkTimedOutTasks)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 20,
+				retries: 1, // Only 1 retry allowed
+				pollInterval: 15,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			// Manually set up a task in processing state that has already exhausted retries
+			const client = (customProvider as any)._client;
+			const taskId = "exhausted-task";
+			const taskData = {
+				id: taskId,
+				data: { message: "test" },
+				timestamp: Date.now(),
+			};
+
+			// Store task data
+			await client.set(`${testQueue}:task:${taskId}`, JSON.stringify(taskData));
+			// Set attempt count to max retries (already tried once)
+			await client.set(`${testQueue}:task:${taskId}:attempt`, "1");
+			// Add to processing with expired deadline
+			await client.zadd(`${testQueue}:processing`, Date.now() - 1000, taskId);
+
+			// Register handler to start polling (which will run checkTimedOutTasks)
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {},
+			});
+
+			// Wait for checkTimedOutTasks to process the expired task
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// Task should have been moved to DLQ
+			const dlqTasks = await customProvider.getDeadLetterTasks(testQueue);
+			expect(dlqTasks.length).toBe(1);
+			expect(dlqTasks[0].id).toBe(taskId);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should requeue timed out task via checkTimedOutTasks when retries remaining", async () => {
+			// This test specifically targets lines 361-363 (requeue in checkTimedOutTasks)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 20,
+				retries: 5,
+				pollInterval: 15,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			// Manually set up a task in processing state that still has retries
+			const client = (customProvider as any)._client;
+			const taskId = "retry-task";
+			const taskData = {
+				id: taskId,
+				data: { message: "test" },
+				timestamp: Date.now(),
+			};
+
+			// Store task data
+			await client.set(`${testQueue}:task:${taskId}`, JSON.stringify(taskData));
+			// Set attempt count to less than max retries
+			await client.set(`${testQueue}:task:${taskId}:attempt`, "1");
+			// Add to processing with expired deadline
+			await client.zadd(`${testQueue}:processing`, Date.now() - 1000, taskId);
+
+			// Register handler to start polling
+			let handlerCalled = false;
+			await customProvider.dequeue(testQueue, {
+				id: "test-handler",
+				handler: async () => {
+					handlerCalled = true;
+				},
+			});
+
+			// Wait for checkTimedOutTasks to requeue and then process
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// Task should have been requeued and processed
+			expect(handlerCalled).toBe(true);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should handle extend resetting existing timeout handle", async () => {
+			// Covers lines 485-489 (reset timeout in extend when timeoutHandle exists)
+			const customProvider = new ValkeyTaskProvider({
+				timeout: 200,
+				pollInterval: 50,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let completed = false;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					// First extend sets a new timeout
+					await ctx.extend(500);
+					// Second extend resets the existing timeout handle
+					await ctx.extend(500);
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					completed = true;
+					await ctx.ack();
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 300));
+
+			expect(completed).toBe(true);
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should auto-reject and clear timeout on handler error", async () => {
+			// Covers lines 520-524 (catch block auto-reject + finally clearing timeout)
+			const customProvider = new ValkeyTaskProvider({
+				retries: 1,
+				pollInterval: 50,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			let handlerCalled = false;
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async () => {
+					handlerCalled = true;
+					throw new Error("Intentional handler error");
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+			await customProvider.enqueue(testQueue, { data: { message: "test" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(handlerCalled).toBe(true);
+
+			// Task should be in dead-letter queue after failing
+			const stats = await customProvider.getQueueStats(testQueue);
+			expect(stats).toEqual({
+				deadLetter: 1,
+				waiting: 0,
+				processing: 0,
+			});
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+
+		test("should force disconnect with destroy", async () => {
+			// Covers lines 601-604 (force disconnect path)
+			const customProvider = new ValkeyTaskProvider();
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			await customProvider.disconnect(true);
+
+			// Client should be destroyed
+			expect(customProvider.taskHandlers.size).toBe(0);
+		});
+
+		test("should handle disconnect when not connected", async () => {
+			// Covers line 598 (connectionPromise is null)
+			const customProvider = new ValkeyTaskProvider();
+
+			// Disconnect without ever connecting - should not throw
+			await customProvider.disconnect();
+
+			expect(customProvider.taskHandlers.size).toBe(0);
+		});
+
+		test("should handle force disconnect when client is already closed", async () => {
+			// Covers lines 602-604 (force disconnect when client not open)
+			const customProvider = new ValkeyTaskProvider();
+			await customProvider.connect();
+
+			// Close normally first
+			const client = (customProvider as any)._client;
+			if (client.status === "ready") {
+				await client.quit();
+			}
+
+			// Force disconnect when already closed - should not throw
+			await customProvider.disconnect(true);
+
+			expect(customProvider.taskHandlers.size).toBe(0);
+		});
+
+		test("should handle graceful disconnect when client is already closed", async () => {
+			// Covers lines 606-608 (graceful disconnect when client not open)
+			const customProvider = new ValkeyTaskProvider();
+			await customProvider.connect();
+
+			// Close the client directly
+			const client = (customProvider as any)._client;
+			if (client.status === "ready") {
+				await client.quit();
+			}
+
+			// Graceful disconnect when already closed - should not throw
+			await customProvider.disconnect(false);
+
+			expect(customProvider.taskHandlers.size).toBe(0);
+		});
+
+		test("should return tasks from dead-letter queue", async () => {
+			// Covers lines 620-627 (getDeadLetterTasks iteration)
+			const customProvider = new ValkeyTaskProvider({
+				retries: 1,
+				pollInterval: 50,
+			});
+			customProvider.throwOnEmptyListeners = false;
+			await customProvider.connect();
+			await customProvider.clearQueue(testQueue);
+
+			const handler: TaskHandler = {
+				id: "test-handler",
+				handler: async (_task: Task, ctx: TaskContext) => {
+					await ctx.reject(false); // Send directly to DLQ
+				},
+			};
+
+			await customProvider.dequeue(testQueue, handler);
+
+			// Enqueue multiple tasks that will all go to DLQ
+			await customProvider.enqueue(testQueue, { data: { message: "dlq-1" } });
+			await customProvider.enqueue(testQueue, { data: { message: "dlq-2" } });
+
+			await new Promise((resolve) => setTimeout(resolve, 300));
+
+			const deadLetterTasks =
+				await customProvider.getDeadLetterTasks(testQueue);
+			expect(deadLetterTasks.length).toBe(2);
+			const messages = deadLetterTasks.map((t) => (t.data as any).message);
+			expect(messages).toContain("dlq-1");
+			expect(messages).toContain("dlq-2");
+
+			await customProvider.clearQueue(testQueue);
+			await customProvider.disconnect();
+		});
+	});
+});

--- a/packages/valkey/tsconfig.json
+++ b/packages/valkey/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "Node16",
+        "moduleResolution": "Node16",
+        "declaration": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "lib": ["ESNext", "DOM"]
+    }
+}

--- a/packages/valkey/vitest.config.ts
+++ b/packages/valkey/vitest.config.ts
@@ -1,0 +1,16 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['test/*.ts'],
+		coverage: {
+			reporter: ['text', 'json', 'lcov'],
+			exclude: [
+				'vitest.config.ts',
+				'dist/**',
+				'test/**',
+				'src/types.ts',
+			],
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,18 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(@opentelemetry/api@1.9.1)
 
+  packages/valkey:
+    dependencies:
+      hookified:
+        specifier: ^3.0.0
+        version: 3.0.0
+      iovalkey:
+        specifier: ^0.3.3
+        version: 0.3.3
+      qified:
+        specifier: workspace:^
+        version: link:../qified
+
   packages/zeromq:
     dependencies:
       qified:
@@ -401,6 +413,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@iovalkey/commands@0.1.0':
+    resolution: {integrity: sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==}
 
   '@jaredwray/fumanchu@4.7.0':
     resolution: {integrity: sha512-EgUBpTCY+fbkSBapOovcGZR4oGY/PMvO+/WgldW8NTQqFuWxIkzxquQEXLxfBi0P1cQIB1c8mprOFABP8VfFig==}
@@ -1036,6 +1051,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1361,6 +1380,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  iovalkey@0.3.3:
+    resolution: {integrity: sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==}
+    engines: {node: '>=18.12.0'}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -1549,6 +1572,12 @@ packages:
     resolution: {integrity: sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==}
     engines: {node: '>=16'}
     hasBin: true
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -1931,6 +1960,14 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   redis@6.0.0:
     resolution: {integrity: sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==}
     engines: {node: '>= 20.0.0'}
@@ -2061,6 +2098,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -2611,6 +2651,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@iovalkey/commands@0.1.0': {}
+
   '@jaredwray/fumanchu@4.7.0':
     dependencies:
       '@cacheable/memory': 2.0.9
@@ -3118,6 +3160,8 @@ snapshots:
 
   defu@6.1.7: {}
 
+  denque@2.1.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3515,6 +3559,20 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  iovalkey@0.3.3:
+    dependencies:
+      '@iovalkey/commands': 0.1.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -3663,6 +3721,10 @@ snapshots:
   liquidjs@10.27.0:
     dependencies:
       commander: 10.0.1
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   longest-streak@3.1.0: {}
 
@@ -4360,6 +4422,12 @@ snapshots:
 
   react@19.2.7: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   redis@6.0.0(@opentelemetry/api@1.9.1):
     dependencies:
       '@redis/bloom': 6.0.0(@redis/client@6.0.0(@opentelemetry/api@1.9.1))
@@ -4587,6 +4655,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@4.1.0: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — adds a new `@qified/valkey` provider, plus a distributed-safety hardening of the task-queue engine shared with `@qified/redis`.

## Why

Valkey is the Linux Foundation's fork of Redis OSS 7.2.4. It uses the RESP wire protocol and keeps full command compatibility with Redis 7.2, so it supports everything `@qified/redis` relies on: `PUBLISH`/`SUBSCRIBE`/`UNSUBSCRIBE` pub/sub, the string/list/sorted-set commands behind the task queue, duplicated connections, and RESP2/RESP3.

## What

A new `@qified/valkey` package that mirrors `@qified/redis`, built on the [`iovalkey`](https://github.com/valkey-io/iovalkey) client (the valkey-io org's fork of ioredis, also used by `@keyv/valkey`):

- **`ValkeyMessageProvider`** — pub/sub via a publisher connection plus a duplicated subscriber connection.
- **`ValkeyTaskProvider`** — a reliable task queue over lists + sorted sets with visibility timeout, retries, dead-letter queues, and `Hookified` error events.
- **`createQified()`** factory plus the same exported option types/defaults as the Redis package.

Connections use `redis://` URIs (iovalkey speaks RESP to Valkey); the package defaults to `redis://localhost:6380` to coexist with Redis on 6379 in the shared dev/CI stack.

### Repo wiring
- `docker-compose.yaml`: a `valkey/valkey:latest` service on host port `6380`.
- `.github/workflows/code-coverage.yaml`: upload `packages/valkey/coverage/lcov.info`.
- root `README.md`: list `@qified/valkey`.

### iovalkey lifecycle note
Unlike node-redis, an iovalkey client's `status` transitions to `end` asynchronously and a closed client can't be reopened, so the task provider creates a fresh client on reconnect and tolerates a redundant `quit()`.

## Review-driven hardening (applied to both providers)

Automated reviewers (Gemini, Codex) surfaced a set of correctness/robustness issues, all pre-existing in `@qified/redis`. Fixed in both packages so they stay in sync:

- **Message provider:** guard `JSON.parse` against malformed messages; prevent a throwing handler from raising an unhandled rejection; roll back the `subscriptions` map entry if the initial `SUBSCRIBE` fails; `unref()` per-task timers.
- **Task engine — atomic claim + fencing tokens (distributed correctness):** the claim/ack/reject/extend/timeout-recovery paths are now atomic Lua scripts.
  - **CLAIM** atomically RPOPs the ready list and ZADDs to processing (with a server-clock deadline), bumping the attempt + fence counters in one script, so a worker crash can never leave a task in neither structure.
  - Each delivery carries a monotonic **fence token**; an operation from a delivery that lost ownership (timed out and re-claimed elsewhere) is a **no-op**, so a stale worker can't corrupt a newer delivery. The token is consumed on every ownership transition.
  - **Timeout recovery** re-verifies expiry inside the script against the server clock, so a second poller can't evict a healthy re-claimed delivery.
  - Delivery is at-least-once; handlers should be idempotent (documented on the class). Standalone/Sentinel only (not Cluster).

The distributed design was reviewed adversarially before implementation (which caught three race-condition bugs in the first draft — token not consumed on reject, recovery not re-checking expiry, and a claim script that could error after RPOP — all fixed).

## Testing

- `pnpm --filter @qified/valkey test` and `pnpm --filter @qified/redis test` — **88 tests each at 100% coverage**, against live Valkey **9.1.0** and Redis, including deterministic fencing tests (stale ack/reject/extend no-ops, first-finalizer-wins, recovery invalidation, orphan cleanup).
- **Two-instance smoke test:** 50 tasks across two competing provider instances → each delivered exactly once, no loss, no double-claim.
- `pnpm build` succeeds for all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017r93iF34k329SSDVBBLSdH