### PR TITLE
mono - chore: upgrade hookified

### DIFF
--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@nats-io/jetstream": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",
-    "hookified": "^3.0.0"
+    "hookified": "^3.0.1"
   },
   "peerDependencies": {
     "qified": "workspace:^"

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -47,6 +47,6 @@
     "LICENSE"
   ],
   "dependencies": {
-    "hookified": "^3.0.0"
+    "hookified": "^3.0.1"
   }
 }

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "amqplib": "^2.0.1",
-    "hookified": "^3.0.0"
+    "hookified": "^3.0.1"
   },
   "peerDependencies": {
     "qified": "workspace:^"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -38,7 +38,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "dependencies": {
-    "hookified": "^3.0.0",
+    "hookified": "^3.0.1",
     "redis": "^6.0.0"
   },
   "peerDependencies": {

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -38,7 +38,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "dependencies": {
-    "hookified": "^3.0.0",
+    "hookified": "^3.0.1",
     "iovalkey": "^0.3.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -57,8 +57,8 @@ importers:
   packages/qified:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
 
   packages/rabbitmq:
     dependencies:
@@ -66,8 +66,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -75,8 +75,8 @@ importers:
   packages/redis:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -87,8 +87,8 @@ importers:
   packages/valkey:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       iovalkey:
         specifier: ^0.3.3
         version: 0.3.3
@@ -1465,6 +1465,10 @@ packages:
 
   hookified@3.0.0:
     resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
+
+  hookified@3.0.1:
+    resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
     engines: {node: '>=22.18.0'}
 
   html-dom-parser@8.0.0:
@@ -3761,6 +3765,8 @@ snapshots:
   hookified@2.2.0: {}
 
   hookified@3.0.0: {}
+
+  hookified@3.0.1: {}
 
   html-dom-parser@8.0.0:
     dependencies:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — runtime dependency upgrade of `hookified` across all provider packages. No source changes.

## Versions
- `hookified` `^3.0.0` → `^3.0.1` — in `qified`, `@qified/nats`, `@qified/rabbitmq`, `@qified/redis`, `@qified/valkey`

Patch bump; `hookified` is a first-party package on the workspace `minimumReleaseAgeExclude` list.

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — qified 132, nats 80, rabbitmq 114, redis 88, valkey 88, zeromq 8; 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014cLAa8HaTokNu5wBM7cM6x)_