### PR TITLE
release: v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/mono",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "engines": {

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/nats",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "NATS message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qified",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Task and Message Queues with Multiple Providers",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/rabbitmq",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "RabbitMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/redis",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Redis message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/valkey",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Valkey message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/zeromq",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "ZeroMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Release summary
Lockstep release of all packages `0.12.0 → 0.13.0` (minor): the new `@qified/valkey` provider plus atomic, fencing-token task-claim safety for `@qified/redis` and `@qified/valkey`, on top of a dependency/tooling refresh.

## Packages
| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `@qified/valkey` | `0.12.0` | `0.13.0` | **minor** | new provider + fencing-token safety — **first npm publish** | 5 |
| `@qified/redis` | `0.12.0` | `0.13.0` | **minor** | atomic claim + fencing tokens; `redis` 6.0→6.1 | 5 |
| `qified` | `0.12.0` | `0.13.0` | **minor** | lockstep; `hookified` 3.0.1 | 1 |
| `@qified/nats` | `0.12.0` | `0.13.0` | **minor** | lockstep; `hookified` 3.0.1 | 1 |
| `@qified/rabbitmq` | `0.12.0` | `0.13.0` | **minor** | lockstep; `hookified` 3.0.1 | 1 |
| `@qified/zeromq` | `0.12.0` | `0.13.0` | **minor** | lockstep (fixed-version) | 0 |
| `@qified/mono` (root) | `0.12.0` | `0.13.0` | _private_ | not published; bumped to hold lockstep | — |

## v0.13.0 — 2026-07-16

Adds the @qified/valkey provider and makes Redis/Valkey task claims atomic with fencing tokens.

### Features
- add the `@qified/valkey` provider — Valkey pub/sub + a reliable task queue on the `iovalkey` client, mirroring `@qified/redis` (5ceaed2, #205)

  ```ts
  import { createQified } from "@qified/valkey";
  import type { Message } from "qified";

  const qified = createQified({ uri: "redis://localhost:6380" });
  await qified.subscribe("example-topic", {
    async handler(message: Message) { console.log(message); },
  });
  await qified.publish("example-topic", { id: "1", data: "Hello from Valkey!" });
  ```
- atomic task claim with per-delivery fencing tokens for `@qified/redis` and `@qified/valkey` — claim/ack/reject/extend/timeout-recovery are now single Lua scripts, so a worker that lost ownership becomes a no-op and a crash can't strand a task or corrupt a newer delivery. Delivery is at-least-once; handlers should be idempotent (47d3087, #205)

### Bug Fixes
- Redis/Valkey: roll back the subscription entry when the initial `SUBSCRIBE` fails, prevent a throwing handler from raising an unhandled rejection, and `unref()` per-task timers (0a594fa, #205)
- Redis/Valkey: harden task claim, extend, and message parsing against malformed input (bddcf8b, #205)

### Internal
- upgrade `redis` `6.0.0` → `6.1.0` in `@qified/redis` (d73e014, #210)
- upgrade `hookified` `3.0.0` → `3.0.1` across all providers (b460fee, #209)
- pin `.nvmrc` to Node `24.18.0` and align `@types/node` to `^24.13.3` (c89aefb, #212)
- raise root `engines.node` floor to `^22.19.0` to match the docula→undici toolchain (15761a8, #211)
- upgrade `docula` `2.0.0` → `2.2.0` (6806ab5, #208)
- upgrade `tsx` → `4.23.0` and `tsdown` → `0.22.4` (89e0fec, #207)
- upgrade `@biomejs/biome` → `2.5.3`, `vitest` + `@vitest/coverage-v8` → `4.1.10` (661fc4f, #206)

### Contributors
- @jaredwray

### Full List of Changes
- feat(valkey): add @qified/valkey provider by @jaredwray in #205
- mono - chore: upgrade code quality dependencies by @jaredwray in #206
- mono - chore: upgrade TypeScript build tooling by @jaredwray in #207
- mono - chore: upgrade docula by @jaredwray in #208
- mono - chore: upgrade hookified by @jaredwray in #209
- @qified/redis - chore: upgrade redis by @jaredwray in #210
- mono - chore: raise root engines.node floor to 22.19 by @jaredwray in #211
- mono - chore: pin .nvmrc to Node 24 and align @types/node by @jaredwray in #212

**Full diff:** https://github.com/jaredwray/qified/compare/v0.12.0...v0.13.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds — no lockfile change (workspace cross-deps use `workspace:^`)
- [x] `pnpm build` succeeds — all packages compile
- [x] `pnpm test` passes locally — qified 132, nats 80, rabbitmq 114, redis 88, valkey 88, zeromq 8; 100% coverage (provider suites run against live Docker services)
- [x] No changes outside the version bump (no `CHANGELOG.md` is kept in this repo — notes live here and in the GitHub Release)

## Post-merge
- Merge, then **create a GitHub Release at tag `v0.13.0`** with the notes above — the `release.yaml` workflow (`release: [released]`) runs `pnpm publish:packages`, publishing all 6 packages to npm via OIDC trusted publishing with provenance.
- ⚠️ **First-time publish for `@qified/valkey`:** it was added in #205, after the OIDC setup (#203/#204) that covered the original 5 packages. Before releasing, add its npm **Trusted Publisher** (org `jaredwray`, repo `qified`, workflow `release.yaml`) — otherwise the OIDC publish will fail auth for that one package. The other 5 are already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014cLAa8HaTokNu5wBM7cM6x)_