### PR TITLE
mono - chore: remove @ungap/structured-clone override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@ungap/structured-clone': '>=1.3.1'
-
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,6 @@
 packages:
   - packages/*
 
-# Transitive-dep pins for security advisories.
-# @ungap/structured-clone <1.3.1 — CWE-502 deserialization fix.
-overrides:
-  "@ungap/structured-clone": ">=1.3.1"
-
 # Supply-chain controls — see jaredwray/agentic defense-in-depth-nodejs.md § 4
 minimumReleaseAge: 10080 # 7 days, in minutes
 minimumReleaseAgeStrict: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — drop a stale workspace override. No runtime or source changes.

## Summary
Remove the `@ungap/structured-clone` `>=1.3.1` pin. After deletion, `pnpm install` still resolves `1.3.1` (the CWE-502 floor), so the parent tree has caught up and the override is no longer needed.

## Changes
- remove `@ungap/structured-clone` from `pnpm-workspace.yaml` `overrides`
- drop the matching lockfile override entry (resolved version stays `1.3.1`)

## Verification
- [x] `pnpm why @ungap/structured-clone` → `1.3.1`
- [x] `pnpm build` passes
- [x] `pnpm --filter qified test` — 132 tests, 100% statements/lines
- [x] `pnpm --filter @qified/zeromq test` — 8 tests, 100% statements/lines
- [x] CI `tests` (Node 22/24/26), `code-coverage`, and CodeQL are green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

