### PR TITLE
@qified/valkey - chore: upgrade iovalkey

### DIFF
--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "hookified": "^3.0.1",
-    "iovalkey": "^0.3.3"
+    "iovalkey": "^0.4.0"
   },
   "peerDependencies": {
     "qified": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       iovalkey:
-        specifier: ^0.3.3
-        version: 0.3.3
+        specifier: ^0.4.0
+        version: 0.4.0
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -1503,8 +1503,8 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
-  iovalkey@0.3.3:
-    resolution: {integrity: sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==}
+  iovalkey@0.4.0:
+    resolution: {integrity: sha512-OSUKxJ+s44CLdUTaicX4+pVrBN/zHKIYwr2oKhRDuczr19FwcSCXEZHzcMUYWZNh1mNSCV9bNJHW/T6cHVm9Aw==}
     engines: {node: '>=18.12.0'}
 
   ipaddr.js@2.4.0:
@@ -3775,7 +3775,7 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  iovalkey@0.3.3:
+  iovalkey@0.4.0:
     dependencies:
       '@iovalkey/commands': 0.1.0
       cluster-key-slot: 1.1.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — runtime dependency upgrade of the `iovalkey` client in `@qified/valkey`. No source changes.

## Summary
Upgrade `iovalkey` to the `pnpm outdated` Latest. Build succeeded against `0.4.0` with no API changes in this package.

## Changes
- `iovalkey` `^0.3.3` → `^0.4.0` (`@qified/valkey`)

## Verification
- [x] `pnpm --filter @qified/valkey build` passes
- [x] `pnpm --filter @qified/valkey lint` passes
- [x] CI `tests` (Node 22/24/26), `code-coverage`, and CodeQL are green (Valkey integration tests run against the live service in CI)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

