### PR TITLE
mono - chore: upgrade hookified

### DIFF
--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@nats-io/jetstream": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0",
-    "hookified": "^3.0.1"
+    "hookified": "^3.0.2"
   },
   "peerDependencies": {
     "qified": "workspace:^"

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -47,6 +47,6 @@
     "LICENSE"
   ],
   "dependencies": {
-    "hookified": "^3.0.1"
+    "hookified": "^3.0.2"
   }
 }

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "amqplib": "^2.0.1",
-    "hookified": "^3.0.1"
+    "hookified": "^3.0.2"
   },
   "peerDependencies": {
     "qified": "workspace:^"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -38,7 +38,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "dependencies": {
-    "hookified": "^3.0.1",
+    "hookified": "^3.0.2",
     "redis": "^6.2.0"
   },
   "peerDependencies": {

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -38,7 +38,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "dependencies": {
-    "hookified": "^3.0.1",
+    "hookified": "^3.0.2",
     "iovalkey": "^0.4.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -54,8 +54,8 @@ importers:
   packages/qified:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
 
   packages/rabbitmq:
     dependencies:
@@ -63,8 +63,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -72,8 +72,8 @@ importers:
   packages/redis:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       qified:
         specifier: workspace:^
         version: link:../qified
@@ -84,8 +84,8 @@ importers:
   packages/valkey:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       iovalkey:
         specifier: ^0.4.0
         version: 0.4.0
@@ -1456,12 +1456,12 @@ packages:
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
-  hookified@3.0.0:
-    resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
-    engines: {node: '>=22.18.0'}
-
   hookified@3.0.1:
     resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
+    engines: {node: '>=22.18.0'}
+
+  hookified@3.0.2:
+    resolution: {integrity: sha512-FpIcRHpFlW7yh68lmL0h1/Vodv77TogpHlt4qqakE/0RyQMjgNxs53acH9NJPeyRZutP7GnlqiyqRNejV8/lHQ==}
     engines: {node: '>=22.18.0'}
 
   html-dom-parser@8.0.0:
@@ -3615,7 +3615,7 @@ snapshots:
 
   hashery@3.0.0:
     dependencies:
-      hookified: 3.0.0
+      hookified: 3.0.1
 
   hasown@2.0.4:
     dependencies:
@@ -3737,9 +3737,9 @@ snapshots:
 
   hookified@2.2.0: {}
 
-  hookified@3.0.0: {}
-
   hookified@3.0.1: {}
+
+  hookified@3.0.2: {}
 
   html-dom-parser@8.0.0:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — runtime dependency upgrade of `hookified` across all packages that depend on it. No source changes.

## Summary
Upgrade `hookified` to the `pnpm outdated` Latest. Patch bump; `hookified` is on the workspace `minimumReleaseAgeExclude` list.

## Changes
- `hookified` `^3.0.1` → `^3.0.2` in `qified`, `@qified/nats`, `@qified/rabbitmq`, `@qified/redis`, `@qified/valkey`

## Verification
- [x] `pnpm build` passes
- [x] `pnpm --filter qified test` — 132 tests, 100% statements/lines
- [x] lint clean on nats, rabbitmq, redis, valkey, zeromq
- [x] CI `tests` (Node 22/24/26), `code-coverage`, and CodeQL are green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

