### PR TITLE
mono - chore: pin Docker Valkey service image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - "6379:6379" # Redis port
 
   valkey:
-    image: valkey/valkey:latest
+    image: valkey/valkey:9.1.1
     container_name: valkey
     ports:
       - "6380:6379" # Valkey port (host 6380; redis already uses 6379)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — pin the Valkey Docker Compose test-service image from a floating tag to a concrete version.

## Summary
`valkey/valkey:latest` currently resolves to Valkey 9.1.1 (same digest as `valkey/valkey:9.1.1` / `valkey/valkey:9.1.1-trixie`). Pin to that tag so test runs are reproducible.

## Changes
- `docker-compose.yaml` `valkey` service: `valkey/valkey:latest` → `valkey/valkey:9.1.1`

## Verification
- [x] Compose YAML still parses
- [x] `crane digest valkey/valkey:latest` equals `crane digest valkey/valkey:9.1.1` (`sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd`)
- [x] CI `tests` (Node 22/24/26), `code-coverage`, and CodeQL are green with `valkey/valkey:9.1.1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

