### PR TITLE
@qified/zeromq - fix: drop socket filter on last unsubscribe

### DIFF
--- a/packages/zeromq/src/index.ts
+++ b/packages/zeromq/src/index.ts
@@ -158,6 +158,7 @@ export class ZmqMessageProvider implements MessageProvider {
 			}
 		} else {
 			this.subscriptions.delete(topic);
+			this._subscriber?.unsubscribe(topic);
 		}
 	}
 

--- a/packages/zeromq/src/index.ts
+++ b/packages/zeromq/src/index.ts
@@ -173,7 +173,6 @@ export class ZmqMessageProvider implements MessageProvider {
 
 		this.subscriptions.clear();
 
-		// Close sockets and wait for them to fully close to free the port
 		this._subscriber?.close();
 		this._publisher?.close();
 

--- a/packages/zeromq/src/index.ts
+++ b/packages/zeromq/src/index.ts
@@ -148,6 +148,8 @@ export class ZmqMessageProvider implements MessageProvider {
 	 * @returns {Promise<void>} A promise that resolves when the unsubscription is complete.
 	 */
 	public async unsubscribe(topic: string, id?: string): Promise<void> {
+		const hadTopic = this.subscriptions.has(topic);
+
 		if (id) {
 			const current = this.subscriptions.get(topic);
 			if (current) {
@@ -164,7 +166,7 @@ export class ZmqMessageProvider implements MessageProvider {
 			this.subscriptions.delete(topic);
 		}
 
-		if (!this.subscriptions.has(topic)) {
+		if (hadTopic && !this.subscriptions.has(topic)) {
 			this._subscriber?.unsubscribe(topic);
 		}
 	}

--- a/packages/zeromq/src/index.ts
+++ b/packages/zeromq/src/index.ts
@@ -155,9 +155,16 @@ export class ZmqMessageProvider implements MessageProvider {
 					topic,
 					current.filter((sub) => sub.id !== id),
 				);
+
+				if (this.subscriptions.get(topic)?.length === 0) {
+					this.subscriptions.delete(topic);
+				}
 			}
 		} else {
 			this.subscriptions.delete(topic);
+		}
+
+		if (!this.subscriptions.has(topic)) {
 			this._subscriber?.unsubscribe(topic);
 		}
 	}

--- a/packages/zeromq/src/index.ts
+++ b/packages/zeromq/src/index.ts
@@ -174,8 +174,8 @@ export class ZmqMessageProvider implements MessageProvider {
 		this.subscriptions.clear();
 
 		// Close sockets and wait for them to fully close to free the port
-		await this._subscriber?.close();
-		await this._publisher?.close();
+		this._subscriber?.close();
+		this._publisher?.close();
 
 		this._subscriber = undefined;
 		this._publisher = undefined;

--- a/packages/zeromq/test/index.test.ts
+++ b/packages/zeromq/test/index.test.ts
@@ -203,6 +203,20 @@ describe("ZmqMessageProvider", () => {
 		await provider.disconnect();
 	});
 
+	test("should unsubscribe remaining topics on disconnect", async () => {
+		const provider = new ZmqMessageProvider({ uri: "tcp://localhost:5560" });
+		await provider.subscribe("test-topic", {
+			id: "handler",
+			async handler() {},
+		});
+
+		expect(provider.subscriptions.has("test-topic")).toBe(true);
+
+		await provider.disconnect();
+
+		expect(provider.subscriptions.size).toBe(0);
+	});
+
 	test("should create Qified instance with ZeroMQ provider", () => {
 		const qified = createQified();
 		expect(qified).toBeInstanceOf(Qified);

--- a/packages/zeromq/test/index.test.ts
+++ b/packages/zeromq/test/index.test.ts
@@ -198,9 +198,38 @@ describe("ZmqMessageProvider", () => {
 
 	test("should allow unsubscribe before any subscription", async () => {
 		const provider = new ZmqMessageProvider();
-		await provider.unsubscribe("test-topic", "missing");
-		expect(provider.subscriptions.size).toBe(0);
-		await provider.disconnect();
+		const unsubscribeSpy = vi.spyOn(Subscriber.prototype, "unsubscribe");
+
+		try {
+			await provider.unsubscribe("test-topic", "missing");
+			expect(provider.subscriptions.size).toBe(0);
+			expect(unsubscribeSpy).not.toHaveBeenCalled();
+		} finally {
+			unsubscribeSpy.mockRestore();
+			await provider.disconnect();
+		}
+	});
+
+	test("should not unsubscribe the socket for an unknown topic", async () => {
+		const provider = new ZmqMessageProvider({ uri: "tcp://localhost:5561" });
+		const unsubscribeSpy = vi.spyOn(Subscriber.prototype, "unsubscribe");
+
+		try {
+			await provider.subscribe("test-topic", {
+				id: "handler",
+				async handler() {},
+			});
+			unsubscribeSpy.mockClear();
+
+			await provider.unsubscribe("unknown-topic", "handler");
+			await provider.unsubscribe("another-unknown");
+
+			expect(unsubscribeSpy).not.toHaveBeenCalled();
+			expect(provider.subscriptions.has("test-topic")).toBe(true);
+		} finally {
+			unsubscribeSpy.mockRestore();
+			await provider.disconnect();
+		}
 	});
 
 	test("should unsubscribe remaining topics on disconnect", async () => {

--- a/packages/zeromq/test/index.test.ts
+++ b/packages/zeromq/test/index.test.ts
@@ -118,6 +118,37 @@ describe("ZmqMessageProvider", () => {
 		await qified.disconnect();
 	});
 
+	test("should remove the topic once the last subscriber is gone", async () => {
+		const provider = new ZmqMessageProvider({ uri: "tcp://localhost:5556" });
+		const message: Omit<Message, "providerId"> = { id: "1", data: "test" };
+		const topic = "test-topic";
+		const id = "test-handler";
+		await provider.subscribe(topic, {
+			id,
+			async handler(message) {
+				void message;
+			},
+		});
+
+		// Let the event loop iterate so message queue is read/written at next tick
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+
+		await provider.publish(topic, message);
+
+		// Let the event loop iterate so message queue is read/written at next tick
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 100);
+		});
+
+		await provider.unsubscribe(topic, id);
+
+		expect(provider.subscriptions.get(topic)).toBeUndefined();
+
+		await provider.disconnect();
+	});
+
 	test("should create Qified instance with ZeroMQ provider", () => {
 		const qified = createQified();
 		expect(qified).toBeInstanceOf(Qified);

--- a/packages/zeromq/test/index.test.ts
+++ b/packages/zeromq/test/index.test.ts
@@ -1,5 +1,6 @@
 import { type Message, Qified } from "qified";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+import { Subscriber } from "zeromq";
 import {
 	createQified,
 	defaultZmqId,
@@ -118,34 +119,87 @@ describe("ZmqMessageProvider", () => {
 		await qified.disconnect();
 	});
 
-	test("should remove the topic once the last subscriber is gone", async () => {
-		const provider = new ZmqMessageProvider({ uri: "tcp://localhost:5556" });
-		const message: Omit<Message, "providerId"> = { id: "1", data: "test" };
+	test("should keep the topic until the last subscriber is gone", async () => {
+		const provider = new ZmqMessageProvider({ uri: "tcp://localhost:5559" });
 		const topic = "test-topic";
-		const id = "test-handler";
-		await provider.subscribe(topic, {
-			id,
-			async handler(message) {
-				void message;
-			},
-		});
+		const firstId = "first-handler";
+		const secondId = "second-handler";
+		const unsubscribeSpy = vi.spyOn(Subscriber.prototype, "unsubscribe");
+		const firstMessage: Omit<Message, "providerId"> = { id: "1", data: "one" };
+		const secondMessage: Omit<Message, "providerId"> = { id: "2", data: "two" };
+		let firstReceived: Message | undefined;
+		let secondReceived: Message | undefined;
 
-		// Let the event loop iterate so message queue is read/written at next tick
-		await new Promise<void>((resolve) => {
-			setTimeout(resolve, 100);
-		});
+		try {
+			await provider.subscribe(topic, {
+				id: firstId,
+				async handler(message) {
+					firstReceived = message;
+				},
+			});
+			await provider.subscribe(topic, {
+				id: secondId,
+				async handler(message) {
+					secondReceived = message;
+				},
+			});
 
-		await provider.publish(topic, message);
+			// Let the event loop iterate so message queue is read/written at next tick
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
 
-		// Let the event loop iterate so message queue is read/written at next tick
-		await new Promise<void>((resolve) => {
-			setTimeout(resolve, 100);
-		});
+			await provider.publish(topic, firstMessage);
 
-		await provider.unsubscribe(topic, id);
+			// Let the event loop iterate so message queue is read/written at next tick
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
 
-		expect(provider.subscriptions.get(topic)).toBeUndefined();
+			expect(firstReceived).toEqual({
+				...firstMessage,
+				providerId: "@qified/zeromq",
+			});
+			expect(secondReceived).toEqual({
+				...firstMessage,
+				providerId: "@qified/zeromq",
+			});
+			expect(provider.subscriptions.get(topic)?.length).toBe(2);
 
+			await provider.unsubscribe(topic, firstId);
+
+			expect(provider.subscriptions.get(topic)?.length).toBe(1);
+			expect(unsubscribeSpy).not.toHaveBeenCalled();
+
+			firstReceived = undefined;
+			secondReceived = undefined;
+			await provider.publish(topic, secondMessage);
+
+			// Let the event loop iterate so message queue is read/written at next tick
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, 100);
+			});
+
+			expect(firstReceived).toBeUndefined();
+			expect(secondReceived).toEqual({
+				...secondMessage,
+				providerId: "@qified/zeromq",
+			});
+
+			await provider.unsubscribe(topic, secondId);
+
+			expect(provider.subscriptions.get(topic)).toBeUndefined();
+			expect(unsubscribeSpy).toHaveBeenCalledWith(topic);
+		} finally {
+			unsubscribeSpy.mockRestore();
+			await provider.disconnect();
+		}
+	});
+
+	test("should allow unsubscribe before any subscription", async () => {
+		const provider = new ZmqMessageProvider();
+		await provider.unsubscribe("test-topic", "missing");
+		expect(provider.subscriptions.size).toBe(0);
 		await provider.disconnect();
 	});
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix — unsubscribe the ZeroMQ socket when the last handler for a topic is removed.

## Summary
Rebase of [#214](https://github.com/jaredwray/qified/pull/214) onto current `main`, including the review follow-ups. The fork branch could not be force-pushed (GitHub App cannot update workflow files on the fork). Original commits from `@techntools` are preserved.

## Changes
- Drop the in-memory topic and the ZeroMQ socket filter when the last handler is removed (by id or for the whole topic)
- Call socket `unsubscribe` only when the topic was present and is now gone
- Remove the redundant `await` on `Socket.close()` (`close()` is `void`)
- Tests for last-handler cleanup, remaining-handler delivery, unknown topics, and disconnect-while-subscribed

## Verification
- [x] `pnpm test` in `@qified/zeromq` — 100% line coverage
- [x] CI `tests` (Node 22/24/26), `code-coverage`, and CodeQL

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc3c90fa-6471-4062-a89e-0c2ac88d53e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

