### PR TITLE
mono - chore: defense - apply Node.js defense-in-depth file controls

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+	"install": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "Node.js",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
+	"postCreateCommand": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# High-risk paths. Last matching pattern wins.
+# Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
+/.github/ @jaredwray
+/.cursor/ @jaredwray
+/.devcontainer/ @jaredwray
+/scripts/ @jaredwray

--- a/.github/workflows/check-workflows.yaml
+++ b/.github/workflows/check-workflows.yaml
@@ -1,0 +1,28 @@
+name: Check Workflows
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -19,6 +19,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js
@@ -28,7 +33,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build    
       run: pnpm build

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -42,6 +42,12 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
+
     - name: Enable corepack
       run: corepack enable
 
@@ -52,7 +58,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Enable corepack
       run: corepack enable

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,6 +18,8 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        cache: 'pnpm'
+        package-manager-cache: false
 
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -17,6 +17,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js
@@ -26,7 +31,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,14 @@ on:
 # long-lived NPM_TOKEN is needed and provenance attestations are generated.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,37 @@ permissions:
   contents: read
 
 jobs:
+  aikido-gate:
+    name: Aikido release gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: Install Aikido CI client
+        run: sfw npm install --global @aikidosec/ci-api-client@1.0.17
+      - name: Run Aikido release scan
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          AIKIDO_CLIENT_API_KEY: ${{ secrets.AIKIDO_CLIENT_API_KEY }}
+        run: >
+          aikido-api-client scan-release
+          "$REPO_NAME" "$GITHUB_SHA"
+          --apikey "$AIKIDO_CLIENT_API_KEY"
+          --fail-on-sast-scan --fail-on-iac-scan --fail-on-secrets-scan
+
   build:
 
+    needs: [aikido-gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        cache: 'pnpm'
+        package-manager-cache: false
 
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js
@@ -32,7 +37,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js ${{ matrix.node-version }}
@@ -33,7 +38,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build    
       run: pnpm build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Enable corepack
       run: corepack enable
     - name: Use Node.js ${{ matrix.node-version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,11 @@ Qified is a task and message queue library with multiple providers, built with T
 - `packages/nats/` - NATS provider
 - `packages/zeromq/` - ZeroMQ provider
 - `site/` - Website assets
+
+## Safe Chain
+
+Package installs in this environment go through Aikido Safe Chain shims. Never bypass them:
+
+- Keep `~/.safe-chain/shims` first on `PATH`.
+- Do not call unshimmed `npm`, `pnpm`, `npx`, or `pnpx`.
+- Do not install packages with `curl | sh` or by pointing at a package manager outside the shim directory.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -42,7 +42,7 @@ Profile: npm library · public
 - [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR #227 pending)
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified on main
 - [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR #227 pending)
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
+- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #227 pending)
 - [ ] `persist-credentials: false` on checkouts that don't push (PR #227 pending)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified on main
 - [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -41,7 +41,7 @@ Profile: npm library · public
 
 - [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR #227 pending)
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified on main
-- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR #227 pending)
 - [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
 - [ ] `persist-credentials: false` on checkouts that don't push (PR #227 pending)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -1,0 +1,63 @@
+# Defense in Depth
+
+Tracking against https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md.
+
+Profile: npm library · public
+
+## 1. Security docs
+
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+
+## 2. Repository lockdown
+
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] Lockdown script run; `lockdown-repo.sh --check` passes clean
+- [ ] Pull requests required on the default branch (0 required approving reviews, last-push approval off, code-owner review of owned paths, Restrict updates off; the owner may merge without a review); force pushes and deletion blocked
+- [ ] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`)
+- [ ] Tag ruleset "Tags only by admins" active
+- [ ] Workflow runs from all outside collaborators require approval
+- [ ] Default workflow token read-only; Actions cannot create or approve PRs
+- [ ] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`)
+- [ ] Secret scanning + push protection enabled *(plan-gated on private repos)*
+- [ ] Private vulnerability reporting enabled *(public repos only)*
+- [ ] Dependabot alerts enabled
+- [ ] Dependabot rule: auto-dismiss low + medium (manual)
+- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
+- [ ] Recovery codes stored offline in a password manager (manual)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
+
+## 3. Dependencies (pnpm)
+
+- [x] `packageManager: pnpm@11.x` pinned in `package.json` — verified on main
+- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified on main (`minimumReleaseAgeExclude: hookified`)
+- [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — verified on main (reviewed `allowBuilds`: esbuild, sharp, unrs-resolver, workerd, zeromq)
+- [x] `blockExoticSubdeps: true` — verified on main
+- [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — verified on main
+- [x] Dependency-update tooling opens PRs only — never auto-merge — verified on main (no Dependabot/Renovate auto-merge)
+- [x] New direct dependencies get human review; prefer `~` ranges over `^` — verified standing practice (existing ranges unchanged)
+
+## 4. GitHub Actions
+
+- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow
+- [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified on main
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
+- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
+- [ ] `persist-credentials: false` on checkouts that don't push
+- [x] No `pull_request_target` on workflows that run untrusted PR code — verified on main
+- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning
+- [x] No npm tokens (or other registry credentials) in Actions secrets — verified on main
+
+## 5. npm publishing — npm libraries only
+
+- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual)
+- [ ] Drydock connected — staged releases reviewed before promotion (manual)
+- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified on main
+
+## 6. Security tooling
+
+- [ ] Aikido runs on every build
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
+- [x] Socket reviews every PR that changes dependencies — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -25,7 +25,7 @@ Profile: npm library · public
 - [ ] Dependabot rule: auto-dismiss low + medium (manual)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #227 pending)
 
 ## 3. Dependencies (pnpm)
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -58,6 +58,6 @@ Profile: npm library · public
 
 ## 6. Security tooling
 
-- [ ] Aikido runs on every build
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
+- [x] Aikido runs on every build — verified on main (Aikido Security GitHub app)
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR #227 pending)
 - [x] Socket reviews every PR that changes dependencies — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -11,7 +11,7 @@ Profile: npm library · public
 
 ## 2. Repository lockdown
 
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #227 pending)
 - [ ] Lockdown script run; `lockdown-repo.sh --check` passes clean
 - [ ] Pull requests required on the default branch (0 required approving reviews, last-push approval off, code-owner review of owned paths, Restrict updates off; the owner may merge without a review); force pushes and deletion blocked
 - [ ] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -39,7 +39,7 @@ Profile: npm library · public
 
 ## 4. GitHub Actions
 
-- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow
+- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR #227 pending)
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified on main
 - [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
 - [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -43,7 +43,7 @@ Profile: npm library · public
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified on main
 - [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
 - [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
-- [ ] `persist-credentials: false` on checkouts that don't push
+- [ ] `persist-credentials: false` on checkouts that don't push (PR #227 pending)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified on main
 - [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -45,7 +45,7 @@ Profile: npm library · public
 - [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #227 pending)
 - [ ] `persist-credentials: false` on checkouts that don't push (PR #227 pending)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified on main
-- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning
+- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning (PR #227 pending)
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified on main
 
 ## 5. npm publishing — npm libraries only

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -6,8 +6,8 @@ Profile: npm library · public
 
 ## 1. Security docs
 
-- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
-- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR #227 pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #227 pending)
 
 ## 2. Repository lockdown
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,28 @@
-# Security Policy - Reporting a Vulnerability
+# Security Policy
 
-We maintain these libraries on a continual basis and monitor issues constantly. If there is a vulnerability (on the latest major version) please create an issue ASAP and we will address it as soon as possible.
+We take security seriously and work to keep this project up to date. If you discover a security vulnerability, please report it **privately** so we can investigate and ship a fix before the issue becomes public.
+
+## Reporting a vulnerability
+
+Please use one of the following private channels — **do not open a public issue, pull request, or discussion** for security concerns:
+
+1. **Preferred:** open a private report via GitHub's [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) flow on this repository's **Security** tab.
+2. **Email:** send the details to me@jaredwray.com. If the issue is urgent, include `[SECURITY]` in the subject line and we will respond as soon as possible.
+
+When reporting, please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof-of-concept.
+- The affected version(s) and platform.
+- Any suggested remediation, if you have one.
+
+We will acknowledge receipt, work with you on a coordinated disclosure timeline, and credit you in the advisory once a fix is published unless you ask to remain anonymous.
+
+## How this repository is secured
+
+This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
+
+- Every GitHub Action is pinned to a full commit SHA.
+- Dependencies install through pnpm 11 with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default (reviewed `allowBuilds` exceptions only). CI installs with a frozen lockfile.
+- Socket reviews every pull request that changes dependencies.
+- npm releases authenticate with OIDC trusted publishing and provenance. There are no npm tokens in Actions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,10 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 
 ## How this repository is secured
 
-This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
+This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
+hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- Every GitHub Action is pinned to a full commit SHA.
-- Dependencies install through pnpm 11 with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default (reviewed `allowBuilds` exceptions only). CI installs with a frozen lockfile.
-- Socket reviews every pull request that changes dependencies.
+- CI runs with least-privilege permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
+- Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.
 - npm releases authenticate with OIDC trusted publishing and provenance. There are no npm tokens in Actions.

--- a/scripts/setup-cloud-environment.sh
+++ b/scripts/setup-cloud-environment.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# setup-cloud-environment.sh — Aikido Safe Chain bootstrap for Codespaces and Cursor Cloud Agents.
+#
+# Fail closed: never install dependencies unless Safe Chain shims are on PATH.
+# Copied into the target repo as scripts/setup-cloud-environment.sh.
+
+set -euo pipefail
+
+export SAFE_CHAIN_VERSION="1.5.15"
+SAFE_CHAIN_INSTALLER_SHA256="de0565e3d6346407a604e84e639e95fea8758748063da2216bbfdca5feda5dd2"
+SAFE_CHAIN_INSTALLER_URL="https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh"
+SAFE_CHAIN_SHIMS="${HOME}/.safe-chain/shims"
+SAFE_CHAIN_BIN="${HOME}/.safe-chain/bin"
+
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+	cd "$git_root"
+fi
+
+if [[ ! -f pnpm-lock.yaml ]]; then
+	echo "error: pnpm-lock.yaml is required; refusing to install without a frozen lockfile" >&2
+	exit 1
+fi
+
+if [[ -f package.json ]] && grep -q '"packageManager"' package.json && command -v corepack >/dev/null; then
+	corepack enable
+fi
+
+if ! command -v pnpm >/dev/null; then
+	echo "error: pnpm is required on PATH before Safe Chain can wrap it" >&2
+	exit 1
+fi
+
+installer=$(mktemp)
+trap 'rm -f "$installer"' EXIT
+
+curl -fsSL "$SAFE_CHAIN_INSTALLER_URL" -o "$installer"
+echo "${SAFE_CHAIN_INSTALLER_SHA256} ${installer}" | sha256sum -c -
+
+sh "$installer" --ci
+
+export PATH="${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:${PATH}"
+
+persist_shim_path() {
+	local rc="$1"
+	local line="export PATH=\"${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:\$PATH\""
+	if [[ -f "$rc" ]] && grep -Fq ".safe-chain/shims" "$rc"; then
+		return 0
+	fi
+	mkdir -p "$(dirname "$rc")"
+	printf '\n# Aikido Safe Chain shims\n%s\n' "$line" >> "$rc"
+}
+
+persist_shim_path "${HOME}/.profile"
+persist_shim_path "${HOME}/.bashrc"
+persist_shim_path "${HOME}/.zshrc"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+	printf '%s\n' "$SAFE_CHAIN_SHIMS" >> "$GITHUB_PATH"
+	printf '%s\n' "$SAFE_CHAIN_BIN" >> "$GITHUB_PATH"
+fi
+
+pnpm safe-chain-verify
+pnpm install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply the defense-in-depth-nodejs file controls: private SECURITY.md reporting, DEFENSE_IN_DEPTH.md tracking, CODEOWNERS, Aikido Safe Chain cloud bootstrap, least-privilege and SHA-pinned CI with Socket Firewall and zizmor, disabled publish-job caches, and an Aikido scan-release gate on npm publish.

## Status update

- `DEFENSE_IN_DEPTH.md`: § 1 docs, CODEOWNERS, Safe Chain, § 4 workflow items, and Aikido release gate → (PR #227 pending)
- Already-true items reconciled as `[x] — verified on main` (pnpm baseline, SHA pins, no `pull_request_target`, no npm tokens, `repository.url`, Socket PR reviews, Aikido GitHub app)

## Changes

- Rewrite SECURITY.md for private reporting; list only controls this PR puts in place
- Add DEFENSE_IN_DEPTH.md (`Profile: npm library · public`)
- Add `.github/CODEOWNERS` for `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` (`@jaredwray`)
- Copy `scripts/setup-cloud-environment.sh` and wire Codespaces / Cursor Cloud Agents; append Safe Chain notes to AGENTS.md
- Least-privilege `permissions` (codeql `{}` + per-job; release `id-token: write` on the publish job only)
- `persist-credentials: false` on every checkout that does not push
- Socket Firewall Free `1.15.0` on every job; `sfw pnpm install --frozen-lockfile`
- `.github/workflows/check-workflows.yaml` (zizmor)
- `package-manager-cache: false` on release and Cloudflare Pages deploy
- `aikido-gate` job; publish `needs:` it

## Maintainer follow-up (not in this PR)

This token is not a repo admin. After merge, run:

```bash
lockdown-repo.sh jaredwray/qified \
  --required-checks "build (22),build (24),build (26),zizmor" \
  --allowed-actions "codecov/*,cloudflare/*"
```

`--check` from this environment: 9 settings not in the desired state (403 on Actions permission APIs; no branch/tag rulesets; secret scanning unavailable via this token; private vulnerability reporting off; Dependabot alerts off; no CODEOWNERS on `main` yet).

Manual npm-side items (packages: `qified`, `@qified/redis`, `@qified/valkey`, `@qified/rabbitmq`, `@qified/nats`, `@qified/zeromq`):

- Configure OIDC trusted publishing **stage-only** on npmjs.com
- Switch CI from live `pnpm publish` to `npm stage publish`; promote with 2FA
- Connect Drydock
- Require 2FA and disallow tokens
- Add repo secret `AIKIDO_CLIENT_API_KEY` so the new release gate can call `scan-release`
- Dependabot auto-dismiss low+medium; phishing-resistant 2FA; recovery codes offline

## Verification

- [x] `npx actions-up` reports all actions up to date
- [x] Workflow YAML parses
- [x] `lockdown-repo.sh --check` run (audit only; apply requires admin)
- [ ] CI on this PR

## Reference

defense-in-depth-nodejs §§ 1–6

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

