### PR TITLE
mono - chore: defense - mark merged checklist items from PR #227

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -6,26 +6,26 @@ Profile: npm library · public
 
 ## 1. Security docs
 
-- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR #227 pending)
-- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #227 pending)
+- [x] `SECURITY.md` present — contact info + "How this repository is secured" summary — PR #227
+- [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #227
 
 ## 2. Repository lockdown
 
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #227 pending)
+- [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #227
 - [ ] Lockdown script run; `lockdown-repo.sh --check` passes clean
 - [ ] Pull requests required on the default branch (0 required approving reviews, last-push approval off, code-owner review of owned paths, Restrict updates off; the owner may merge without a review); force pushes and deletion blocked
-- [ ] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`)
+- [ ] Merges blocked unless required status checks pass (`--required-checks "build (22),build (24),build (26),zizmor"`)
 - [ ] Tag ruleset "Tags only by admins" active
 - [ ] Workflow runs from all outside collaborators require approval
 - [ ] Default workflow token read-only; Actions cannot create or approve PRs
-- [ ] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`)
+- [ ] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions "codecov/*,cloudflare/*"`)
 - [ ] Secret scanning + push protection enabled *(plan-gated on private repos)*
 - [ ] Private vulnerability reporting enabled *(public repos only)*
 - [ ] Dependabot alerts enabled
 - [ ] Dependabot rule: auto-dismiss low + medium (manual)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #227 pending)
+- [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #227
 
 ## 3. Dependencies (pnpm)
 
@@ -33,19 +33,19 @@ Profile: npm library · public
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified on main (`minimumReleaseAgeExclude: hookified`)
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — verified on main (reviewed `allowBuilds`: esbuild, sharp, unrs-resolver, workerd, zeromq)
 - [x] `blockExoticSubdeps: true` — verified on main
-- [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — verified on main
+- [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — verified on main (`sfw pnpm install --frozen-lockfile` in CI)
 - [x] Dependency-update tooling opens PRs only — never auto-merge — verified on main (no Dependabot/Renovate auto-merge)
 - [x] New direct dependencies get human review; prefer `~` ranges over `^` — verified standing practice (existing ranges unchanged)
 
 ## 4. GitHub Actions
 
-- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR #227 pending)
+- [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #227
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified on main
-- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR #227 pending)
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #227 pending)
-- [ ] `persist-credentials: false` on checkouts that don't push (PR #227 pending)
+- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` — PR #227
+- [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #227
+- [x] `persist-credentials: false` on checkouts that don't push — PR #227
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified on main
-- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning (PR #227 pending)
+- [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #227
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified on main
 
 ## 5. npm publishing — npm libraries only
@@ -59,5 +59,5 @@ Profile: npm library · public
 ## 6. Security tooling
 
 - [x] Aikido runs on every build — verified on main (Aikido Security GitHub app)
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR #227 pending)
+- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` — PR #227
 - [x] Socket reviews every PR that changes dependencies — verified on main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reconcile `DEFENSE_IN_DEPTH.md` after PR #227 merged: mark file items done and leave GitHub lockdown settings plus npm-side `(manual)` items open.

## Status update

- `DEFENSE_IN_DEPTH.md`: `(PR #227 pending)` → `[x] — PR #227` for § 1, CODEOWNERS, Safe Chain, § 4 workflow controls, and the Aikido release gate

## Verification

- [x] CODEOWNERS, Safe Chain bootstrap, workflows, and SECURITY.md match the checked items on `main`
- [x] `lockdown-repo.sh --check` still fails (this token is not a repo admin): no branch/tag rulesets, private vulnerability reporting off, Dependabot alerts off, Actions permission APIs 403

## Maintainer: next catalog item (no file PR)

GitHub lockdown settings. After merging this PR, run as a repo admin:

```bash
lockdown-repo.sh jaredwray/qified \
  --required-checks "build (22),build (24),build (26),zizmor" \
  --allowed-actions "codecov/*,cloudflare/*"
```

Then reply `continue` and I will re-run `--check` and tick the § 2 setting boxes.

`(manual)` leftovers: Dependabot auto-dismiss low+medium; phishing-resistant 2FA; recovery codes; npm stage-only OIDC, Drydock, 2FA/disallow tokens for `qified` and `@qified/{redis,valkey,rabbitmq,nats,zeromq}`. Add `AIKIDO_CLIENT_API_KEY` so the release gate can call `scan-release`.

## Reference

defense-in-depth-nodejs § 2 (reconciliation after § 1–4 / § 6 file items)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

