### PR TITLE
mono - chore: defense - stage npm publishes instead of going live

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,9 @@ on:
     types: [released]
 
 # OIDC trusted publishing to npm requires id-token: write so the job can mint
-# the OIDC token that npm exchanges for a short-lived publish credential. No
-# long-lived NPM_TOKEN is needed and provenance attestations are generated.
+# the OIDC token that npm exchanges for a short-lived credential. CI only
+# stages (`npm stage publish`); a maintainer promotes with 2FA. No long-lived
+# NPM_TOKEN is needed and provenance attestations are generated.
 permissions:
   contents: read
 
@@ -63,7 +64,10 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
+        registry-url: https://registry.npmjs.org
         package-manager-cache: false
+    - name: Install npm for staged publishing
+      run: sfw npm install --global npm@11.19.0
 
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile
@@ -80,5 +84,5 @@ jobs:
     - name: Testing
       run: pnpm test
 
-    - name: Publish
+    - name: Stage publish
       run: pnpm publish:packages

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -51,7 +51,7 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) (PR pending)
+- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) (PR #230 pending)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -51,7 +51,7 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual)
+- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) (PR pending)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified on main

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is a mono repo and uses [pnpm](https://pnpm.io/) for package management. In
    - If you are making a bug fix, use the `patch` version bump. `0.0.X`
 3. Sync the version changes to all packages by running `pnpm version:sync`.
 4. Check the changes and commit them to the main branch.
-5. Do a release on GitHub. This will trigger the GitHub Actions workflow to publish the packages.
+5. Do a release on GitHub. CI stages the packages with `npm stage publish` (they do not go live). A maintainer then reviews (Drydock) and promotes the staged versions with 2FA.
 
 # License
 [MIT & © Jared Wray](LICENSE)

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
+    "build:publish": "pnpm build && npm stage publish --access public --provenance",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && npm stage publish --access public --provenance",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage ./site/dist",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
+    "build:publish": "pnpm build && npm stage publish --access public --provenance",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage ./site/dist",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && npm stage publish --access public --provenance",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
+    "build:publish": "pnpm build && npm stage publish --access public --provenance",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && npm stage publish --access public --provenance",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
+    "build:publish": "pnpm build && npm stage publish --access public --provenance",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && npm stage publish --access public --provenance",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
+    "build:publish": "pnpm build && npm stage publish --access public --provenance",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && npm stage publish --access public --provenance",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm publish --provenance --access public --no-git-checks",
+    "build:publish": "pnpm build && npm stage publish --access public --provenance",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && npm stage publish --access public --provenance",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switch CI from live `pnpm publish` to `npm stage publish` so GitHub releases land in npm's staging queue. A maintainer promotes with 2FA. Lockdown / Actions allowlist stays last so later workflow actions are not frozen yet.

## Status update

- `DEFENSE_IN_DEPTH.md`: § 5 Staged publishing → (PR pending)
- Closed #229 without merging — `lockdown-repo.sh` is not added to this repo

## Changes

- Each package `build:publish` runs `npm stage publish --access public --provenance`
- Release workflow installs `npm@11.19.0` (CLI ≥ 11.15) and sets `registry-url` for OIDC
- README publishing steps describe stage-then-promote

## Maintainer (still manual)

On npmjs.com for `qified` and `@qified/{redis,valkey,rabbitmq,nats,zeromq}`: set the trusted publisher to **stage-only**, connect Drydock, require 2FA and disallow tokens. Add `AIKIDO_CLIENT_API_KEY`.

## Verification

- [x] All six packages use `npm stage publish` (no live `pnpm publish` in `build:publish`)
- [ ] CI on this PR

## Reference

defense-in-depth-nodejs § 5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

