### PR TITLE
mono - chore: defense - mark staged publishing done after PR #230

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -51,7 +51,7 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) (PR #230 pending)
+- [x] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) — PR #230
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified on main

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,4 +26,4 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - CI runs with least-privilege permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.
-- npm releases authenticate with OIDC trusted publishing and provenance. There are no npm tokens in Actions.
+- npm releases authenticate with OIDC trusted publishing and provenance. CI stages with `npm stage publish`; a maintainer promotes with 2FA. There are no npm tokens in Actions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reconcile the checklist after PR #230 merged: CI staged publishing is done. Remaining § 5 items are npmjs.com/Drydock `(manual)`. GitHub `lockdown-repo.sh` stays last (not vendored).

## Status update

- `DEFENSE_IN_DEPTH.md`: § 5 Staged publishing → `[x] — PR #230`
- `SECURITY.md`: CI stages with `npm stage publish`; a maintainer promotes with 2FA

## Maintainer leftovers (no file PR)

- npm trusted publisher **stage-only** for `qified` and `@qified/{redis,valkey,rabbitmq,nats,zeromq}` (workflow `release.yaml`)
- Connect Drydock with a read-only npm token (no GitHub Action on the stage-publish path)
- Require 2FA and disallow tokens
- `AIKIDO_CLIENT_API_KEY` repo secret
- Dependabot auto-dismiss low+medium; phishing-resistant 2FA; recovery codes

After those (or skip), run lockdown last as a repo admin from the skill script — do not add `lockdown-repo.sh` to this repo.

## Verification

- [x] `build:publish` on main packs then `npm stage publish`
- [ ] CI on this PR

## Reference

defense-in-depth-nodejs § 5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

