### PR TITLE
mono - chore: defense - record GitHub lockdown settings as applied

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -12,16 +12,16 @@ Profile: npm library · public
 ## 2. Repository lockdown
 
 - [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #227
-- [ ] Lockdown script run; `lockdown-repo.sh --check` passes clean
-- [ ] Pull requests required on the default branch (0 required approving reviews, last-push approval off, code-owner review of owned paths, Restrict updates off; the owner may merge without a review); force pushes and deletion blocked
-- [ ] Merges blocked unless required status checks pass (`--required-checks "build (22),build (24),build (26),zizmor"`)
-- [ ] Tag ruleset "Tags only by admins" active
-- [ ] Workflow runs from all outside collaborators require approval
-- [ ] Default workflow token read-only; Actions cannot create or approve PRs
-- [ ] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions "codecov/*,cloudflare/*"`)
-- [ ] Secret scanning + push protection enabled *(plan-gated on private repos)*
-- [ ] Private vulnerability reporting enabled *(public repos only)*
-- [ ] Dependabot alerts enabled
+- [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — applied by maintainer 2026-08-17
+- [x] Pull requests required on the default branch (0 required approving reviews, last-push approval off, code-owner review of owned paths, Restrict updates off; the owner may merge without a review); force pushes and deletion blocked — applied by maintainer 2026-08-17
+- [x] Merges blocked unless required status checks pass (`--required-checks "build (22),build (24),build (26),zizmor"`) — applied by maintainer 2026-08-17
+- [x] Tag ruleset "Tags only by admins" active — applied by maintainer 2026-08-17
+- [x] Workflow runs from all outside collaborators require approval — applied by maintainer 2026-08-17
+- [x] Default workflow token read-only; Actions cannot create or approve PRs — applied by maintainer 2026-08-17
+- [x] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions "codecov/*,cloudflare/*"`) — applied by maintainer 2026-08-17
+- [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — applied by maintainer 2026-08-17
+- [x] Private vulnerability reporting enabled *(public repos only)* — applied by maintainer 2026-08-17
+- [x] Dependabot alerts enabled — applied by maintainer 2026-08-17
 - [ ] Dependabot rule: auto-dismiss low + medium (manual)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,9 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
 hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
+- All changes land through pull requests — direct pushes to `main` are blocked, and merging requires passing status checks.
+- Tags (and therefore releases) can only be created by repository admins.
+- Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
 - CI runs with least-privilege permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Record that GitHub lockdown settings are live after you ran `lockdown-repo.sh` as admin. Update `SECURITY.md` so it lists PR-required `main`, admin-only tags, fork-workflow approval, and the Actions allowlist.

## Status update

- `DEFENSE_IN_DEPTH.md`: § 2 setting items → `[x] — applied by maintainer 2026-08-17`
- Left open: Dependabot auto-dismiss low+medium, phishing-resistant 2FA, recovery codes (manual)
- Left open: npm stage-only OIDC, Drydock, 2FA/disallow tokens (manual)

## Verification

- [x] Rulesets `Pull requests required` and `Tags only by admins` are active
- [x] Required checks are `build (22)`, `build (24)`, `build (26)`, `zizmor`
- [x] Private vulnerability reporting enabled
- [x] Maintainer apply log: all 8 lockdown steps succeeded

## Reference

defense-in-depth-nodejs § 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

