### PR TITLE
mono - chore: defense - record stage-only OIDC trusted publishing

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -52,8 +52,8 @@ Profile: npm library · public
 
 - [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual) — completed by maintainer 2026-08-17
 - [x] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) — PR #230
-- [ ] Drydock connected — staged releases reviewed before promotion (manual)
-- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] Drydock connected — staged releases reviewed before promotion (manual) — completed by maintainer 2026-08-17
+- [x] No direct publish rights: package requires 2FA and disallows tokens (manual) — completed by maintainer 2026-08-17
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified on main
 
 ## 6. Security tooling

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -23,8 +23,8 @@ Profile: npm library · public
 - [x] Private vulnerability reporting enabled *(public repos only)* — applied by maintainer 2026-08-17
 - [x] Dependabot alerts enabled — applied by maintainer 2026-08-17
 - [ ] Dependabot rule: auto-dismiss low + medium (manual)
-- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
-- [ ] Recovery codes stored offline in a password manager (manual)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — completed by maintainer 2026-08-17
+- [x] Recovery codes stored offline in a password manager (manual) — completed by maintainer 2026-08-17
 - [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #227
 
 ## 3. Dependencies (pnpm)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -50,7 +50,7 @@ Profile: npm library · public
 
 ## 5. npm publishing — npm libraries only
 
-- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual) — completed by maintainer 2026-08-17
 - [x] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) — PR #230
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -59,5 +59,5 @@ Profile: npm library · public
 ## 6. Security tooling
 
 - [x] Aikido runs on every build — verified on main (Aikido Security GitHub app)
-- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` — PR #227
+- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` — PR #227; `AIKIDO_CLIENT_API_KEY` added by maintainer 2026-08-17
 - [x] Socket reviews every PR that changes dependencies — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -22,7 +22,7 @@ Profile: npm library · public
 - [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — applied by maintainer 2026-08-17
 - [x] Private vulnerability reporting enabled *(public repos only)* — applied by maintainer 2026-08-17
 - [x] Dependabot alerts enabled — applied by maintainer 2026-08-17
-- [ ] Dependabot rule: auto-dismiss low + medium (manual)
+- [x] Dependabot rule: auto-dismiss low + medium (manual) — completed by maintainer 2026-08-17
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — completed by maintainer 2026-08-17
 - [x] Recovery codes stored offline in a password manager (manual) — completed by maintainer 2026-08-17
 - [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #227

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,5 +28,5 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
 - CI runs with least-privilege permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
-- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build. Dependabot alerts High and Critical; low and medium auto-dismiss.
 - npm releases are staged, never published directly: CI publishes via stage-only OIDC trusted publishing, Drydock reviews the exact staged artifact, and a maintainer promotes it with 2FA. There are no npm tokens.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,4 +29,4 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - CI runs with least-privilege permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.
-- npm releases authenticate with OIDC trusted publishing and provenance. CI stages with `npm stage publish`; a maintainer promotes with 2FA. There are no npm tokens in Actions.
+- npm releases use stage-only OIDC trusted publishing and provenance. CI can only `npm stage publish`; a maintainer promotes with 2FA. There are no npm tokens in Actions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,4 +29,4 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - CI runs with least-privilege permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.
-- npm releases use stage-only OIDC trusted publishing and provenance. CI can only `npm stage publish`; a maintainer promotes with 2FA. There are no npm tokens in Actions.
+- npm releases are staged, never published directly: CI publishes via stage-only OIDC trusted publishing, Drydock reviews the exact staged artifact, and a maintainer promotes it with 2FA. There are no npm tokens.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

npm Trusted Publishing for this repo is **stage-only OIDC**. CI publishes to the staging lane only; live npm happens after Drydock review plus 2FA.

This PR records the remaining maintainer-completed items from 2026-08-17:

- Stage-only OIDC trusted publishing
- Drydock review before promotion
- npm 2FA / no-token lockdown
- Aikido CI API key present
- Phishing-resistant 2FA and offline recovery codes
- Dependabot auto-dismiss of low and medium

`DEFENSE_IN_DEPTH.md` is fully checked. No workflow or package-manager config changes in this revision.

## Remaining

None. Catalog complete.

## Test plan

- [x] Docs-only change; `pnpm test` not required for this commit
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ea09fb-f457-4e47-8d5b-6b59ee8da471&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

