### PR TITLE
mono - fix: prefix staged tarball path so npm does not treat it as git

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,4 +95,14 @@ jobs:
       # Prefix with ./ so npm treats the tarball as a local file. A bare
       # packed/*.tgz path is parsed as GitHub owner/repo shorthand (npm npa),
       # which then fails with git ls-remote Permission denied (publickey).
-      run: npm stage publish ./packed/*.tgz --access public --provenance
+      # npm stage publish accepts one package-spec, so stage each tarball.
+      run: |
+        shopt -s nullglob
+        tarballs=(./packed/*.tgz)
+        if [ ${#tarballs[@]} -eq 0 ]; then
+          echo "No tarballs in packed/" >&2
+          exit 1
+        fi
+        for tgz in "${tarballs[@]}"; do
+          npm stage publish "$tgz" --access public --provenance
+        done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,10 +64,7 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        registry-url: https://registry.npmjs.org
         package-manager-cache: false
-    - name: Install npm for staged publishing
-      run: sfw npm install --global npm@11.19.0
 
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile
@@ -84,5 +81,18 @@ jobs:
     - name: Testing
       run: pnpm test
 
+    - name: Pack
+      run: |
+        mkdir -p packed
+        pnpm --filter "./packages/**" -r pack --pack-destination "${PWD}/packed"
+        ls -la packed
+
+    - name: Install npm for staged publishing
+      # zizmor: ignore[adhoc-packages] pin npm 11.19.0 so `npm stage publish` is available
+      run: sfw npm install --global npm@11.19.0
+
     - name: Stage publish
-      run: pnpm publish:packages
+      # Prefix with ./ so npm treats the tarball as a local file. A bare
+      # packed/*.tgz path is parsed as GitHub owner/repo shorthand (npm npa),
+      # which then fails with git ls-remote Permission denied (publickey).
+      run: npm stage publish ./packed/*.tgz --access public --provenance

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance ./packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage ./site/dist",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance ./packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance ./packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance ./packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance ./packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -21,7 +21,7 @@
     "test:ci": "biome check --error-on-warnings && vitest run --coverage",
     "clean": "rimraf ./dist ./coverage",
     "build": "tsdown src/index.ts --format esm --format cjs --dts",
-    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance packed.tgz",
+    "build:publish": "pnpm build && pnpm pack --out packed.tgz && npm stage publish --access public --provenance ./packed.tgz",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for the release workflow.

**Why this change is needed?**
`npm stage publish packed/*.tgz` expands to a bare `dir/file.tgz` path. npm 11+ (`npm-package-arg`) parses that as GitHub `owner/repo` shorthand, so CI runs `git ls-remote ssh://git@github.com/packed/<package>-<version>.tgz.git` and dies with `Permission denied (publickey)`.

This is not an OIDC / trusted-publisher or SSH-key problem. Same failure mode as [jaredwray/docula#482](https://github.com/jaredwray/docula/pull/482).

**What this PR does**
- Pack workspace packages into `packed/` with `pnpm pack`.
- Stage each tarball as `./packed/<file>.tgz` so npa treats it as a local file. `npm stage publish` accepts one package-spec, so the workflow loops instead of passing the glob as multiple args (which npm 11 rejects with `EUSAGE`).
- Drop `registry-url` from `actions/setup-node` so an empty `_authToken` does not block trusted-publisher OIDC (same as the docula release workflow).
- Prefix `./packed.tgz` in each package `build:publish` script so local `pnpm publish:packages` hits the same npa rule.

Workflow-only plus publish-script path prefix; no application source to cover with unit tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b59fcda7-a416-4ac6-a4ab-8f532fd8b964?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b59fcda7-a416-4ac6-a4ab-8f532fd8b964&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

