### PR TITLE
release: v0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/mono",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "engines": {

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/nats",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "NATS message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/qified/package.json
+++ b/packages/qified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qified",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Task and Message Queues with Multiple Providers",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/rabbitmq",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "RabbitMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/redis",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Redis message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/valkey",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Valkey message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/zeromq/package.json
+++ b/packages/zeromq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qified/zeromq",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "ZeroMQ message provider for qified",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release summary
Lockstep release of all packages `0.13.0 → 0.13.1` (patch): ZeroMQ last-unsubscribe now drops the socket filter, npm publish is stage-only, plus dependency and CI hardening.

## Packages
| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `@qified/zeromq` | `0.13.0` | `0.13.1` | **patch** | 1 fix (unsubscribe socket filter) | 3 |
| `@qified/redis` | `0.13.0` | `0.13.1` | **patch** | lockstep; `redis` 6.2.0, `hookified` 3.0.2 | 4 |
| `@qified/valkey` | `0.13.0` | `0.13.1` | **patch** | lockstep; `iovalkey` 0.4.0, `hookified` 3.0.2 | 4 |
| `qified` | `0.13.0` | `0.13.1` | **patch** | lockstep; `hookified` 3.0.2 | 3 |
| `@qified/nats` | `0.13.0` | `0.13.1` | **patch** | lockstep; `hookified` 3.0.2 | 3 |
| `@qified/rabbitmq` | `0.13.0` | `0.13.1` | **patch** | lockstep; `hookified` 3.0.2 | 3 |
| `@qified/mono` (root) | `0.13.0` | `0.13.1` | _private_ | not published; bumped to hold lockstep | 18 |

## v0.13.1 — 2026-08-17

Fixes ZeroMQ last-unsubscribe socket filters and switches npm publish to stage-only.

### Bug Fixes
- drop the ZeroMQ socket filter when the last handler unsubscribes from a topic (`85fb7e7`, #226)

### Internal
- remove the `@ungap/structured-clone` pnpm override (`1e6ed26`, #215)
- upgrade `@biomejs/biome` to `2.5.7` (`e492f2c`, #216)
- upgrade `tsx` to `4.23.11` and `tsdown` to `0.22.14` (`78ea233`, #217)
- SHA-pin GitHub Actions and bump `actions/checkout` / `actions/setup-node` to v7 (`1085e5c`, #218)
- upgrade `redis` to `6.2.0` in `@qified/redis` (`e961bc5`, #219)
- upgrade `iovalkey` to `0.4.0` in `@qified/valkey` (`f78d53e`, #220)
- upgrade `hookified` to `3.0.2` across qified and the nats/rabbitmq/redis/valkey providers (`aef66f8`, #221)
- pin Docker Redis to `8.10.0` (`c7b7013`, #222)
- pin Docker Valkey to `9.1.1` (`595be5f`, #223)
- pin Docker NATS service image (`d216b04`, #224)
- pin Docker RabbitMQ service image (`f2e5525`, #225)
- apply Node.js defense-in-depth file controls (Safe Chain, Socket Firewall, CODEOWNERS, Aikido release gate) (`a89163b`, #227)
- mark merged checklist items from #227 (`5518457`, #228)
- stage npm publishes with `npm stage publish` instead of going live; pack tarballs first so `workspace:` peer ranges resolve (`071a964`, #230)
- record staged-publishing and GitHub lockdown status (`6d92777`, #231; `3a96c45`, #232; `4336340`, #233)

### Contributors
- @jaredwray
- @techntools

### Full List of Changes
- mono - chore: remove @ungap/structured-clone override by @jaredwray in #215
- mono - chore: upgrade code quality dependencies by @jaredwray in #216
- mono - chore: upgrade TypeScript and build tooling by @jaredwray in #217
- mono - chore: upgrade GitHub Actions (breaking) by @jaredwray in #218
- @qified/redis - chore: upgrade redis by @jaredwray in #219
- @qified/valkey - chore: upgrade iovalkey by @jaredwray in #220
- mono - chore: upgrade hookified by @jaredwray in #221
- mono - chore: pin Docker Redis service image by @jaredwray in #222
- mono - chore: pin Docker Valkey service image by @jaredwray in #223
- mono - chore: pin Docker NATS service image by @jaredwray in #224
- mono - chore: pin Docker RabbitMQ service image by @jaredwray in #225
- @qified/zeromq - fix: drop socket filter on last unsubscribe by @jaredwray in #226
- mono - chore: defense - apply Node.js defense-in-depth file controls by @jaredwray in #227
- mono - chore: defense - mark merged checklist items from PR #227 by @jaredwray in #228
- mono - chore: defense - stage npm publishes instead of going live by @jaredwray in #230
- mono - chore: defense - mark staged publishing done after PR #230 by @jaredwray in #231
- mono - chore: defense - record GitHub lockdown settings as applied by @jaredwray in #232
- mono - chore: defense - record stage-only OIDC trusted publishing by @jaredwray in #233

**Full diff:** https://github.com/jaredwray/qified/compare/v0.13.0...v0.13.1

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds — no lockfile change (workspace cross-deps use `workspace:^`)
- [x] `pnpm build` succeeds — all packages compile
- [x] `pnpm test` passes locally — qified 132, nats 80, rabbitmq 114, redis 88, valkey 88, zeromq 12; 100% statement coverage (provider suites run against live Docker services)
- [x] No uncommitted changes outside the version bump (no `CHANGELOG.md` is kept in this repo — notes live here and in the GitHub Release)

## Post-merge
- Merge, then **create a GitHub Release at tag `v0.13.1`** with the notes above — the `release.yaml` workflow (`release: [released]`) runs `pnpm publish:packages`.
- CI **stages** packages with `npm stage publish` (they do not go live). After Drydock review, a maintainer promotes the staged versions with 2FA.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19e87a83-d684-41e4-906d-0aa1ebdad04f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19e87a83-d684-41e4-906d-0aa1ebdad04f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

